### PR TITLE
Fix warnings related to catch all exceptions

### DIFF
--- a/shared/test/scala/upickle/FailureTests.scala
+++ b/shared/test/scala/upickle/FailureTests.scala
@@ -63,7 +63,7 @@ object FailureTests extends TestSuite{
             read[Int](failureCase)
           }
         }catch{
-          case e =>
+          case _:Throwable =>
             println("DIDN'T FAIL: " + failureCase)
         }
       }


### PR DESCRIPTION
This is a minor change on my way to warming up to uPickle!

Without this fix `sbt test` produces a couple of warnings of the following kind:

```
[warn] /Users/ramnivas/external-dev/upickle/jvm/shared/test/scala/upickle/FailureTests.scala:66: This catches all Throwables. If this is really intended, use `case e : Throwable` to clear this warning.
[warn]           case e =>
[warn]                ^
```
