### PR TITLE
Allow custom writers to specify ignoring a value

### DIFF
--- a/js/src/main/scala/upickle/json/package.scala
+++ b/js/src/main/scala/upickle/json/package.scala
@@ -32,6 +32,9 @@ package object json {
     case Js.Null => null
     case Js.Arr(children@_*) => js.Array(children.map(writeJs(_)):_*)
     case Js.Obj(kvs@_*) => js.Dictionary(kvs.map{case (k, v) => (k, writeJs(v))}:_*)
+    case Js.None =>
+      // Cannot happen, since we are filtering it out in GeneratedUtil.arrayToMap()
+      throw new IllegalStateException("Js.None value cannot be rendered")
   }
 
   def write(v: Js.Value): String =

--- a/jvm/src/main/scala/upickle/json/Jawn.scala
+++ b/jvm/src/main/scala/upickle/json/Jawn.scala
@@ -63,6 +63,9 @@ sealed trait Renderer {
       case Js.Str(s) => renderString(sb, s)
       case Js.Arr(vs@_*) => renderArray(sb, depth, vs)
       case Js.Obj(vs@_*) => renderObject(sb, depth, canonicalizeObject(vs))
+      case Js.None =>
+        // Cannot happen, since we are filtering it out in GeneratedUtil.arrayToMap()
+        throw new IllegalStateException("Js.None value cannot be rendered")
     }
 
   def canonicalizeObject(vs: Seq[(String, Js.Value)]): Iterator[(String, Js.Value)]

--- a/readme.md
+++ b/readme.md
@@ -356,6 +356,10 @@ object Js {
   case object Null extends Value{
     def value = null
   }
+  // Indicates that the value should be ignored during writing (and is unexpected during reading)
+  case object None extends Value{
+    def value = throw new IllegalStateException("value of Js.None accessed")
+  }
 }
 ```
 

--- a/shared/main/scala/upickle/GeneratedUtil.scala
+++ b/shared/main/scala/upickle/GeneratedUtil.scala
@@ -20,7 +20,8 @@ private[upickle] trait GeneratedUtil {
     var i = 0
     val l = a.value.length
     while(i < l){
-      if (defaults(i) != a.value(i)){
+      val value = a.value(i)
+      if (value != defaults(i) && value != Js.None) {
         accumulated(i) = (names(i) -> a.value(i))
       }
       i += 1

--- a/shared/main/scala/upickle/Js.scala
+++ b/shared/main/scala/upickle/Js.scala
@@ -59,5 +59,9 @@ object Js {
   case object Null extends Value{
     def value = null
   }
+  // Indicates that the value should be ignored during writing (and is unexpected during reading)
+  case object None extends Value{
+    def value = throw new IllegalStateException("value of Js.None accessed")
+  }
 }
 

--- a/shared/test/scala/upickle/MacroTests.scala
+++ b/shared/test/scala/upickle/MacroTests.scala
@@ -122,6 +122,20 @@ object Custom {
   case class Thing3(i: Int, s: String) extends ThingBase
 
   object Thing3 extends ThingBaseCompanion[Thing3](new Thing3(_, _))
+
+  case class Thing4(id: Option[Long] = None)
+
+  object Thing4 {
+    implicit val option2Writer = upickle.Writer[Option[Long]]{
+      case None => Js.None
+      case Some(value) => Js.Str(value.toString)
+    }
+
+    implicit val option2Reader = upickle.Reader[Option[Long]]{
+      case Js.None => None
+      case Js.Str(num) => Some(num.toLong)
+    }
+  }
 }
 object MacroTests extends TestSuite{
   import Generic.ADT
@@ -331,6 +345,11 @@ object MacroTests extends TestSuite{
 //                rw(new Custom.CaseThing(1, "s"), """{"i":-99}""")(Reader.macroR, Writer.macroW)
 //                rw(Custom.CaseThing(100), """{"i":0}""")(Reader.macroR, Writer.macroW)
 //        read[Custom.CaseThing]("""{"i":0}""")(Reader.macroR)
+      }
+      'customNestedWithDefault {
+        import Custom.Thing4._ // bring in the implicits defined to override Reader/Writer for Option[Long]
+        rw(Custom.Thing4(None), """{}""")
+        rw(Custom.Thing4(Some(123)), """{"id":"123"}""")
       }
     }
     'performance{


### PR DESCRIPTION
- Fixes #40
- Introduces Js.None, since Js.Null has semantics of Javascript null.
  This allows custom writers to return Js.None to specify that the
  value should be writen to the output.
