### PR TITLE
Bump to Scala.js 0.6.0-M3

### DIFF
--- a/js/src/main/scala/upickle/json/package.scala
+++ b/js/src/main/scala/upickle/json/package.scala
@@ -6,8 +6,8 @@ import scalajs.js
 package object json {
 
   def readJs(value: Any): Js.Value = value match{
-    case s: js.String => Js.Str(s)
-    case n: js.Number => Js.Num(n)
+    case s: String => Js.Str(s)
+    case n: Double => Js.Num(n)
     case true => Js.True
     case false => Js.False
     case null => Js.Null

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,7 +9,7 @@ object Build extends sbt.Build{
   val cross = new utest.jsrunner.JsCrossBuild(
     organization := "com.lihaoyi",
 
-    version := "0.2.6-M1",
+    version := "0.2.6-M3",
     scalaVersion := "2.10.4",
     name := "upickle",
 

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,9 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0-M1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0-M3")
 
-addSbtPlugin("com.lihaoyi" % "utest-js-plugin" % "0.2.5-M1")
-
-
-resolvers += Resolver.url("scala-js-releases",
-  url("http://dl.bintray.com/scala-js/scala-js-releases/"))(
-    Resolver.ivyStylePatterns)
-
+addSbtPlugin("com.lihaoyi" % "utest-js-plugin" % "0.2.5-M3")


### PR DESCRIPTION
The resolver is not needed anymore as Scala.js is pushed to
Maven Central.

See also http://www.scala-js.org/news/2014/12/22/announcing-scalajs-0.6.0-M3/
