### PR TITLE
Refactor macros and add warnings for common issues

### DIFF
--- a/shared/main/scala/upickle/Macros.scala
+++ b/shared/main/scala/upickle/Macros.scala
@@ -1,11 +1,9 @@
 package upickle
 
 import scala.reflect.macros._
-import scala.reflect._
-import scala.annotation.{ClassfileAnnotation, StaticAnnotation}
+import scala.annotation.StaticAnnotation
 import scala.language.experimental.macros
 
-//import acyclic.file
 /**
  * Used to annotate either case classes or their fields, telling uPickle
  * to use a custom string as the key for that class/field rather than the
@@ -20,17 +18,20 @@ class key(s: String) extends StaticAnnotation
  * types you don't have a Reader/Writer in scope for.
  */
 object Macros {
-
   class RW(val short: String, val long: String, val actionNames: Seq[String])
-  object RW{
+
+  object RW {
     object R extends RW("R", "Reader", Seq("apply"))
     object W extends RW("W", "Writer", Seq("unapply", "unapplySeq"))
   }
+
   def macroRImpl[T: c.WeakTypeTag](c: Context) = {
     import c.universe._
     val tpe = weakTypeTag[T].tpe
+
     assert(!tpe.typeSymbol.fullName.startsWith("scala."))
-    val res = c.Expr[Reader[T]]{
+
+    c.Expr[Reader[T]] {
       val x = picklerFor(c)(tpe, RW.R)(
         _.map(p => q"$p.read": Tree)
          .reduce((a, b) => q"$a orElse $b")
@@ -39,135 +40,49 @@ object Macros {
       val msg = "Tagged Object " + tpe.typeSymbol.fullName
       q"""upickle.Internal.validateReader($msg){$x}"""
     }
-//    println(res)
-    res
   }
+
   def macroWImpl[T: c.WeakTypeTag](c: Context) = {
     import c.universe._
     val tpe = weakTypeTag[T].tpe
+
     assert(!tpe.typeSymbol.fullName.startsWith("scala."))
-//    println("macroWImpl " + tpe)
-    val res = c.Expr[Writer[T]]{
+
+    c.Expr[Writer[T]] {
       picklerFor(c)(tpe, RW.W) { things =>
-        if (things.length == 1){
-          q"upickle.Internal.merge0(${things(0)}.write)"
-        }else{
-          things.map(p => q"$p.write": Tree)
-                .reduce((a, b) => q"upickle.Internal.merge($a, $b)")
-        }
+        if (things.length == 1) q"upickle.Internal.merge0(${things(0)}.write)"
+        else things.map(p => q"$p.write": Tree)
+                   .reduce((a, b) => q"upickle.Internal.merge($a, $b)")
       }
     }
-//    println(res)
-    res
   }
 
   /**
-   * Get the custom @key annotation from
-   * the parameter Symbol if it exists
-   */
-  def customKey(c: Context)(sym: c.Symbol): Option[String] = {
-    import c.universe._
-    sym.annotations
-       .find(_.tpe == typeOf[key])
-       .flatMap(_.scalaArgs.headOption)
-       .map{case Literal(Constant(s)) => s.toString}
-  }
-
-  def getCompanion(c: Context)(tpe: c.Type) = {
-    import c.universe._
-    val symTab = c.universe.asInstanceOf[reflect.internal.SymbolTable]
-    val pre = tpe.asInstanceOf[symTab.Type].prefix.asInstanceOf[Type]
-    c.universe.treeBuild.mkAttributedRef(pre, tpe.typeSymbol.companionSymbol)
-  }
-  /**
-   * Generates a pickler for a particuler Type
+   * Generates a pickler for a particular type
    *
    * @param tpe The type we are generating the pickler for
    * @param rw Configuration that determines whether it's a Reader or
-   *           a Writer, together with the various names wihich vary
+   *           a Writer, together with the various names which vary
    *           between those two choices
    * @param treeMaker How to merge the trees of the multiple subpicklers
    *                  into one larger tree
    */
   def picklerFor(c: Context)
                 (tpe: c.Type, rw: RW)
-                (treeMaker: Seq[c.Tree] => c.Tree): c.Tree = {
+                (treeMaker: Seq[c.Tree] => c.Tree): c.Tree =
+  {
+    val pick =
+      if (tpe.typeSymbol.asClass.isTrait) pickleTrait(c)(tpe, rw)(treeMaker)
+      else if (tpe.typeSymbol.isModuleClass) pickleCaseObject(c)(tpe, rw)(treeMaker)
+      else pickleClass(c)(tpe, rw)(treeMaker)
 
     import c.universe._
-//    println("picklerFor " + tpe)
-    val clsSymbol = tpe.typeSymbol.asClass
 
-    def annotate(pickler: Tree) = {
-      val sealedParent = tpe.baseClasses.find(_.asClass.isSealed)
-      sealedParent.fold(pickler){ parent =>
-        val index = customKey(c)(tpe.typeSymbol).getOrElse(tpe.typeSymbol.fullName)
-        q"upickle.Internal.annotate($pickler, $index)"
-      }
-    }
+    val knotName = newTermName("knot" + rw.short)
 
-    val pick = tpe.declaration(nme.CONSTRUCTOR) match {
-      case NoSymbol if clsSymbol.isSealed => // I'm a sealed trait/class!
-        val subPicklers =
-          for(subCls <- clsSymbol.knownDirectSubclasses.toSeq) yield {
-            picklerFor(c)(subCls.asType.toType, rw)(treeMaker)
-          }
-        val combined = treeMaker(subPicklers)
-
-        q"""upickle.${newTermName(rw.long)}[$tpe]($combined)"""
-
-      case x if tpe.typeSymbol.isModuleClass =>
-        val mod = tpe.typeSymbol.asClass.module
-        annotate(q"upickle.Internal.${newTermName("Case0"+rw.short)}[${tpe}]($mod)")
-
-      case x => // I'm a class
-
-        val pickler = {
-
-          val companion = getCompanion(c)(tpe)
-
-          val argSyms =
-            companion.tpe
-               .member(newTermName("apply"))
-               .asMethod
-               .paramss
-               .flatten
-
-          val args = argSyms.map { p =>
-            customKey(c)(p).getOrElse(p.name.toString)
-          }
-
-          val rwName = newTermName(s"Case${args.length}${rw.short}")
-          val className = newTermName(tpe.typeSymbol.name.toString)
-          val actionName = rw.actionNames
-                             .map(newTermName(_))
-                             .find(companion.tpe.member(_) != NoSymbol)
-                             .getOrElse(c.abort(c.enclosingPosition, "None of the following methods were defined: " + rw.actionNames.mkString(" ")))
-
-          val defaults = argSyms.zipWithIndex.map{ case (s, i) =>
-            val defaultName = newTermName("apply$default$" + (i + 1))
-            companion.tpe.member(defaultName) match{
-              case NoSymbol => q"null"
-              case x => q"upickle.writeJs($companion.$defaultName)"
-            }
-          }
-          val typeArgs = tpe match{
-            case TypeRef(pre, sym, args) => args
-            case _ => c.abort(c.enclosingPosition, "Don't know how to handle " + tpe)
-          }
-
-          if (args.length == 0) // 0-arg case classes are treated like `object`s
-            q"upickle.Internal.${newTermName("Case0"+rw.short)}($companion())"
-          else if (args.length == 1 && rw == RW.W) // 1-arg case classes need their output wrapped in a Tuple1
-            q"upickle.Internal.$rwName(x => $companion.$actionName[..$typeArgs](x).map(Tuple1.apply), Array(..$args), Array(..$defaults)): upickle.${newTypeName(rw.long)}[$tpe]"
-          else // Otherwise, reading and writing are kinda identical
-            q"upickle.Internal.$rwName($companion.$actionName[..$typeArgs], Array(..$args), Array(..$defaults)): upickle.${newTypeName(rw.long)}[$tpe]"
-        }
-
-        annotate(pickler)
-    }
-    val knotName = newTermName("knot"+rw.short)
     val i = c.fresh[TermName]("i")
     val x = c.fresh[TermName]("x")
+
     q"""
        upickle.Internal.$knotName{implicit $i: upickle.Knot.${newTypeName(rw.short)}[$tpe] =>
           val $x = $pick
@@ -175,6 +90,144 @@ object Macros {
           $x
         }
      """
+  }
+
+  def pickleTrait(c: Context)
+                 (tpe: c.Type, rw: RW)
+                 (treeMaker: Seq[c.Tree] => c.Tree): c.universe.Tree =
+  {
+    val clsSymbol = tpe.typeSymbol.asClass
+
+    if (!clsSymbol.isSealed) {
+      val msg = s"[error] The referenced trait [[${clsSymbol.name}]] must be sealed."
+      Console.err.println(msg)
+      c.abort(c.enclosingPosition, msg) /* TODO Does not show message. */
+    }
+
+    if (clsSymbol.knownDirectSubclasses.isEmpty) {
+      val msg = s"The referenced trait [[${clsSymbol.name}]] does not have any sub-classes. This may " +
+        "happen due to a limitation of scalac (SI-7046) given that the trait is " +
+        "not in the same package. If this is the case, the hierarchy may be " +
+        "defined using integer constants."
+      Console.err.println(msg)
+      c.abort(c.enclosingPosition, msg) /* TODO Does not show message. */
+    }
+
+    val subPicklers =
+      clsSymbol.knownDirectSubclasses.map(subCls =>
+        picklerFor(c)(subCls.asType.toType, rw)(treeMaker)
+      ).toSeq
+
+    val combined = treeMaker(subPicklers)
+
+    import c.universe._
+    q"""upickle.${newTermName(rw.long)}[$tpe]($combined)"""
+  }
+
+  def pickleCaseObject(c: Context)
+                      (tpe: c.Type, rw: RW)
+                      (treeMaker: Seq[c.Tree] => c.Tree) =
+  {
+    val mod = tpe.typeSymbol.asClass.module
+
+    import c.universe._
+    annotate(c)(tpe)(q"upickle.Internal.${newTermName("Case0"+rw.short)}[$tpe]($mod)")
+  }
+
+  /** If there is a sealed base class, annotate the pickled tree in the JSON
+    * representation with a class label.
+    */
+  def annotate(c: Context)
+              (tpe: c.Type)
+              (pickler: c.universe.Tree) =
+  {
+    import c.universe._
+    val sealedParent = tpe.baseClasses.find(_.asClass.isSealed)
+    sealedParent.fold(pickler) { parent =>
+      val index = customKey(c)(tpe.typeSymbol).getOrElse(tpe.typeSymbol.fullName)
+      q"upickle.Internal.annotate($pickler, $index)"
+    }
+  }
+
+  /**
+   * Get the custom @key annotation from the parameter Symbol if it exists
+   */
+  def customKey(c: Context)(sym: c.Symbol): Option[String] = {
+    import c.universe._
+    sym.annotations
+      .find(_.tpe == typeOf[key])
+      .flatMap(_.scalaArgs.headOption)
+      .map{case Literal(Constant(s)) => s.toString}
+  }
+
+  def pickleClass(c: Context)
+                 (tpe: c.Type, rw: RW)
+                 (treeMaker: Seq[c.Tree] => c.Tree) =
+  {
+    import c.universe._
+
+    val companion = companionTree(c)(tpe)
+
+    val argSyms =
+      companion.tpe
+        .member(newTermName("apply"))
+        .asMethod
+        .paramss
+        .flatten
+
+    val args = argSyms.map { p =>
+      customKey(c)(p).getOrElse(p.name.toString)
+    }
+
+    val rwName = newTermName(s"Case${args.length}${rw.short}")
+
+    val actionName = rw.actionNames
+      .map(newTermName(_))
+      .find(companion.tpe.member(_) != NoSymbol)
+      .getOrElse(c.abort(c.enclosingPosition, "None of the following methods " +
+        "were defined: " + rw.actionNames.mkString(" ")))
+
+    val defaults = argSyms.zipWithIndex.map { case (s, i) =>
+      val defaultName = newTermName("apply$default$" + (i + 1))
+      companion.tpe.member(defaultName) match{
+        case NoSymbol => q"null"
+        case _ => q"upickle.writeJs($companion.$defaultName)"
+      }
+    }
+
+    val typeArgs = tpe match {
+      case TypeRef(_, _, args) => args
+      case _ => c.abort(c.enclosingPosition, s"Don't know how to handle $tpe")
+    }
+
+    val pickler =
+      if (args.length == 0) // 0-arg case classes are treated like `object`s
+        q"upickle.Internal.${newTermName("Case0"+rw.short)}($companion())"
+      else if (args.length == 1 && rw == RW.W) // 1-arg case classes need their output wrapped in a Tuple1
+        q"upickle.Internal.$rwName(x => $companion.$actionName[..$typeArgs](x).map(Tuple1.apply), Array(..$args), Array(..$defaults)): upickle.${newTypeName(rw.long)}[$tpe]"
+      else // Otherwise, reading and writing are kinda identical
+        q"upickle.Internal.$rwName($companion.$actionName[..$typeArgs], Array(..$args), Array(..$defaults)): upickle.${newTypeName(rw.long)}[$tpe]"
+
+    annotate(c)(tpe)(pickler)
+  }
+
+  def companionTree(c: Context)(tpe: c.Type) = {
+    val companionSymbol = tpe.typeSymbol.companionSymbol
+
+    if (companionSymbol.toString == "<none>") {
+      val clsSymbol = tpe.typeSymbol.asClass
+      val msg = "[error] The companion symbol could not be determined for " +
+        s"[[${clsSymbol.name}]]. This may be due to a bug in scalac (SI-7567) " +
+        "that arises when a case class within a function is pickled. As a " +
+        "workaround, move the declaration to the module-level."
+      Console.err.println(msg)
+      c.abort(c.enclosingPosition, msg) /* TODO Does not show message. */
+    }
+
+    import c.universe._
+    val symTab = c.universe.asInstanceOf[reflect.internal.SymbolTable]
+    val pre = tpe.asInstanceOf[symTab.Type].prefix.asInstanceOf[Type]
+    c.universe.treeBuild.mkAttributedRef(pre, companionSymbol)
   }
 }
  

--- a/shared/main/scala/upickle/package.scala
+++ b/shared/main/scala/upickle/package.scala
@@ -2,7 +2,7 @@ import scala.reflect.ClassTag
 import acyclic.file
 
 /**
- * Picklite tries the following mechanisms for pickling a type
+ * uPickle tries the following mechanisms for pickling a type
  *
  * - Is there an implicit pickler for that type?
  * - Does the companion have matching apply/unapply?

--- a/shared/test/scala/upickle/MacroTests.scala
+++ b/shared/test/scala/upickle/MacroTests.scala
@@ -155,6 +155,21 @@ object MacroTests extends TestSuite{
       * - rw(Obj.ClsB(1), """{"i":1}""")
       * - rw(Obj.ClsA("omg"), """{"s":"omg"}""")
      }
+
+    /*
+    // TODO Currently not supported
+    'declarationWithinFunction {
+      sealed trait Base
+      case object Child extends Base
+      case class Wrapper(base: Base)
+      * - upickle.write(Wrapper(Child))
+    }
+
+    'traitFromOtherPackage {
+      * - upickle.write(subpackage.Wrapper(subpackage.Base.Child))
+    }
+    */
+
     'commonCustomStructures{
       'simpleAdt {
 

--- a/shared/test/scala/upickle/subpackage/Wrapper.scala
+++ b/shared/test/scala/upickle/subpackage/Wrapper.scala
@@ -1,0 +1,7 @@
+package upickle.subpackage
+
+sealed trait Base
+object Base {
+  case object Child extends Base
+}
+case class Wrapper(base: Base)


### PR DESCRIPTION
Splits pickling macros into separate functions. There are
now warnings for the following three cases:

1) Trait is unsealed
2) Trait does not have any sub-classes
3) No companion symbol found for case classes

We are unfortunate to be affected by the two compiler bugs
SI-7046 and SI-7567 which are the cause for 2) and 3). Yet,
the developer can apply simple workarounds as described in
the warnings.

The current suggestion for 2) is to use integer constants:

```scala
type Base = Int  // sealed trait Base
object Base {
  val Child1 = 0 // case object Child1 extends Base
  val Child2 = 1 // case object Child2 extends Base
}
```

A type-safe variant would be to use an approach similar
to https://github.com/lloydmeta/enumeratum/.

As for 3) there may be even a workaround that could be
implemented in uPickle. A possible solution is described
here:

http://stackoverflow.com/questions/16440124/get-the-companion-object-instance-of-a-inner-modul-with-the-scala-reflection-api