### PR TITLE
Reading an invalid object should not throw any exceptions

### DIFF
--- a/upickle/shared/src/main/scala/upickle/Implicits.scala
+++ b/upickle/shared/src/main/scala/upickle/Implicits.scala
@@ -204,7 +204,4 @@ object Internal extends GeneratedInternal{
   def validate[T](name: String)(pf: PartialFunction[Js.Value, T]): PartialFunction[Js.Value, T] = {
     pf.orElse { case x => throw Invalid.Data(x, name) }
   }
-  def validateReader[T](name: String)(r: Reader[T]): Reader[T] = Reader{
-    r.read.orElse { case x => throw Invalid.Data(x, name) }
-  }
 }

--- a/upickle/shared/src/main/scala/upickle/Macros.scala
+++ b/upickle/shared/src/main/scala/upickle/Macros.scala
@@ -32,13 +32,10 @@ object Macros {
     assert(!tpe.typeSymbol.fullName.startsWith("scala."))
 
     c.Expr[Reader[T]] {
-      val x = picklerFor(c)(tpe, RW.R)(
+      picklerFor(c)(tpe, RW.R)(
         _.map(p => q"$p.read": Tree)
          .reduce((a, b) => q"$a orElse $b")
       )
-
-      val msg = "Tagged Object " + tpe.typeSymbol.fullName
-      q"""upickle.Internal.validateReader($msg){$x}"""
     }
   }
 


### PR DESCRIPTION
This currently prevents us from easily defining our own composite
readers, which is often necessary; see #31 and #68. Without the
exceptions, ``implicitly[Reader[_]].read`` calls can be chained using
``orElse()``, as done internally in uPickle.

```scala
sealed trait Base
case class Child1() extends Base
case class Child2() extends Base

import upickle._
implicit val BaseR: Reader[Base] = Reader[Base](
  implicitly[Reader[Child1]].read
    .orElse(implicitly[Reader[Child2]].read)
)
```

The exceptions are only useful for debugging purposes.