### PR TITLE
Implement UUID support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@ Out of the box, uPickle supports writing and reading the following types:
 - Stand-alone `case class`es and `case object`s, and their generic equivalents,
 - Non-generic `case class`es and `case object`s that are part of a `sealed trait` or `sealed class` hierarchy
 - `sealed trait` and `sealed class`es themselves, assuming that all subclasses are picklable
+- `UUID`s
 - `null`
 
 Readability/writability is recursive: a container such as a `Tuple` or `case class` is only readable if all its contents are readable, and only writable if all its contents are writable. That means that you cannot serialize a `List[Any]`, since uPickle doesn't provide a generic way of serializing `Any`. Case classes are only serializable up to 22 fields.

--- a/upickle/shared/src/main/scala/upickle/Implicits.scala
+++ b/upickle/shared/src/main/scala/upickle/Implicits.scala
@@ -11,7 +11,7 @@ import scala.reflect.macros.Context
 import acyclic.file
 import scala.language.higherKinds
 import scala.language.experimental.macros
-
+import java.util.UUID
 
 
 /**
@@ -168,7 +168,8 @@ trait Implicits extends Types {
 
   implicit val DurationR = R[Duration](Internal.validate("DurationString"){FiniteR.read orElse InfiniteR.read})
 
-
+  implicit val UuidR = R[UUID]{case Js.Str(s) => UUID.fromString(s)}
+  implicit val UuidW = W[UUID]{case t: UUID => Js.Str(t.toString)}
 }
 
 /**

--- a/upickle/shared/src/test/scala/upickle/StructTests.scala
+++ b/upickle/shared/src/test/scala/upickle/StructTests.scala
@@ -2,6 +2,7 @@ package upickle
 import utest._
 import scala.concurrent.duration._
 import TestUtil._
+import java.util.UUID
 
 import scala.reflect.ClassTag
 
@@ -144,7 +145,14 @@ object StructTests extends TestSuite{
           listToMap == Map(1 -> "1", 2 -> "2")
         )
       }
+    }
 
+    'extra{
+      val uuidString = "01020304-0506-0708-0901-020304050607"
+      val uuid = UUID.fromString(uuidString)
+      'UUID{
+        rw(uuid, s""" "$uuidString" """)
+      }
     }
   }
 }


### PR DESCRIPTION
As the title says - support for reading and writing UUIDs by default. Simply encode them as strings in UUID format.