### PR TITLE
README: Remove Bintray resolver

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,8 +17,6 @@ Getting Started
 Add the following to your SBT config:
 
 ```scala
-resolvers += "bintray/non" at "http://dl.bintray.com/non/maven"
-
 libraryDependencies += "com.lihaoyi" %% "upickle" % "0.2.8"
 ```
 


### PR DESCRIPTION
As uPickle is pushed to Maven Central, the Bintray resolver is not needed anymore.