### PR TITLE
Small improvement for standard usecase

### DIFF
--- a/upickle/shared/src/test/scala/example/ExampleTests.scala
+++ b/upickle/shared/src/test/scala/example/ExampleTests.scala
@@ -177,7 +177,7 @@ object ExampleTests extends TestSuite{
       }
       'tag{
         write(B(10))                          --> """{"$type":"Bee","i":10}"""
-        read[B]("""{"$type":"Bee","i":10}""") --> B(10)
+        read[A]("""{"$type":"Bee","i":10}""") --> B(10)
       }
     }
   }


### PR DESCRIPTION
Just used trait in read command instead of concrete class. It is more common use case.
