### PR TITLE
Add support for `BigInt` and `BigDecimal`

### DIFF
--- a/project/repo.scala
+++ b/project/repo.scala
@@ -1,3 +1,3 @@
 package object repo{
-  val version = "0.3.6"
+  val version = "0.3.7-SNAPSHOT"
 }

--- a/upickle/shared/src/main/scala-2.10/upickle/BigDecimalSupport.scala
+++ b/upickle/shared/src/main/scala-2.10/upickle/BigDecimalSupport.scala
@@ -1,0 +1,21 @@
+package upickle
+
+import java.math.{ MathContext, BigDecimal => BigDec }
+import scala.math.BigDecimal.defaultMathContext
+
+private[upickle] trait BigDecimalSupport {
+
+  /**
+   *  In Scala 2.10, [[BigDecimal]] constructors always use the default
+   *  [[java.math.MathContext]] so that the input precision is lost sometimes.
+   *
+   *  [[https://github.com/scala/scala/blob/v2.11.7/src/library/scala/math/BigDecimal.scala#L99-L104]]
+   */
+  @inline protected def exactBigDecimal(s: String): BigDecimal = {
+    val repr = new BigDec(s)
+    val mc =
+      if (repr.precision <= defaultMathContext.getPrecision) defaultMathContext
+      else new MathContext(repr.precision, java.math.RoundingMode.HALF_EVEN)
+    BigDecimal(repr, mc)
+  }
+}

--- a/upickle/shared/src/main/scala-2.11/upickle/BigDecimalSupport.scala
+++ b/upickle/shared/src/main/scala-2.11/upickle/BigDecimalSupport.scala
@@ -1,0 +1,6 @@
+package upickle
+
+private[upickle] trait BigDecimalSupport {
+
+  @inline protected def exactBigDecimal(s: String): BigDecimal = BigDecimal(s)
+}

--- a/upickle/shared/src/main/scala/upickle/Implicits.scala
+++ b/upickle/shared/src/main/scala/upickle/Implicits.scala
@@ -17,7 +17,7 @@ import java.util.UUID
 * Typeclasses to allow read/writing of all the common
 * data-types and data-structures in the standard library
 */
-trait Implicits extends Types { imp: Generated =>
+trait Implicits extends Types with BigDecimalSupport { imp: Generated =>
 
 
 
@@ -129,6 +129,8 @@ trait Implicits extends Types { imp: Generated =>
   implicit val LongRW = NumericStringReadWriter[Long](_.toLong)
   implicit val FloatRW = NumericReadWriter(_.toFloat, _.toFloat)
   implicit val DoubleRW = NumericReadWriter(_.toDouble, _.toDouble)
+  implicit val BigIntRW = NumericStringReadWriter[BigInt](BigInt(_))
+  implicit val BigDecimalRW = NumericStringReadWriter[BigDecimal](exactBigDecimal)
 
   import collection.generic.CanBuildFrom
   implicit def SeqishR[V[_], T: R]

--- a/upickle/shared/src/test/scala/upickle/PrimitiveTests.scala
+++ b/upickle/shared/src/test/scala/upickle/PrimitiveTests.scala
@@ -3,7 +3,7 @@ import utest._
 import upickle.legacy.read
 import TestUtil._
 
-object PrimitiveTests extends TestSuite{
+object PrimitiveTests extends TestSuite with BigDecimalSupport {
 
   def tests = TestSuite{
     'Unit{
@@ -33,6 +33,24 @@ object PrimitiveTests extends TestSuite{
       'min-rw(Long.MinValue, """ "-9223372036854775808" """)
       'max-rw(Long.MaxValue, """ "9223372036854775807" """)
       'null-assert(read[Long]("null") == 0)
+    }
+    'BigInt{
+      'whole-rw(BigInt("125123"), """ "125123" """)
+      'fractional-rw(BigInt("1251231542312"), """ "1251231542312" """)
+      'negative-rw(BigInt("-1251231542312"), """ "-1251231542312" """)
+      'big-rw(
+        BigInt("23420744098430230498023841234712512315423127402740234"),
+          """ "23420744098430230498023841234712512315423127402740234" """)
+      'null-rw(null: BigInt, "null")
+    }
+    'BigDecimal{
+      'whole-rw(BigDecimal("125123"), """ "125123" """)
+      'fractional-rw(BigDecimal("125123.1542312"), """ "125123.1542312" """)
+      'negative-rw(BigDecimal("-125123.1542312"), """ "-125123.1542312" """)
+      'big-rw(
+        exactBigDecimal("234207440984302304980238412.15423127402740234"),
+          """ "234207440984302304980238412.15423127402740234" """)
+      'null-rw(null: BigDecimal, "null")
     }
 
     'Int{

--- a/upickleReadme/Readme.scalatex
+++ b/upickleReadme/Readme.scalatex
@@ -326,6 +326,10 @@
       uPickle on the other hand aims much lower: by limiting the scope of the problem to statically-typed, tree-like, immutable data structures, it greatly simplifies both the internal implementation and the external API and behavior of the library. uPickle serializes objects using a very simple set of rules ("Does it have an implicit? Is it a class with @hl.scala{apply}/@hl.scala{unapply} on the companion?") that makes its behavior predictable and simple to understand.
 
   @sect{Version History}
+    @sect{0.3.7}
+      @ul
+        @li
+          Support for @hl.scala{BigInt} and @hl.scala{BigDecimal}
     @sect{0.3.6}
       @ul
         @li


### PR DESCRIPTION
Cross source code seems a bit like an overkill but it clearly shows what to do when we drop Scala 2.10 support. 
