### PR TITLE
(INCOMPLETE) don't use weakTypeOf[existential], refs #116

### DIFF
--- a/pprint/shared/src/main/scala/pprint/PPrint.scala
+++ b/pprint/shared/src/main/scala/pprint/PPrint.scala
@@ -391,7 +391,8 @@ object Internals {
       val t = weakTypeTag[T]
       val d = new Deriver {
         val c: c0.type = c0
-        def typeclass = c.weakTypeTag[pprint.PPrint[_]]
+        def typeclassFor[T: c0.WeakTypeTag]: c0.universe.Type =
+            c.weakTypeTag[pprint.PPrint[T]].tpe
       }
 
       // Fallback manually in case everything fails
@@ -413,7 +414,7 @@ object Internals {
 
     }
   }
-  abstract class Deriver extends Derive[pprint.PPrint]{
+  abstract class Deriver extends Derive{
     import c._
     import c.universe._
 

--- a/upickle/shared/src/main/scala/upickle/Macros.scala
+++ b/upickle/shared/src/main/scala/upickle/Macros.scala
@@ -16,7 +16,7 @@ import language.existentials
  * types you don't have a Reader/Writer in scope for.
  */
 object Macros {
-  abstract class Reading[M[_]] extends Derive[M]{
+  abstract class Reading extends Derive{
     val c: Context
     import c.universe._
     def wrapObject(t: c.Tree) = q"${c.prefix}.SingletonR($t)"
@@ -62,7 +62,7 @@ object Macros {
     def knot(t: Tree) = q"${c.prefix}.Knot.Reader(() => $t)"
 
   }
-  abstract class Writing[M[_]] extends Derive[M]{
+  abstract class Writing extends Derive{
     val c: Context
     import c.universe._
     def wrapObject(obj: c.Tree) = q"${c.prefix}.SingletonW($obj)"
@@ -119,9 +119,10 @@ object Macros {
                          (implicit e1: c0.WeakTypeTag[T], e2: c0.WeakTypeTag[R[_]]): c0.Expr[R[T]] = {
     import c0.universe._
 
-    val res = new Reading[R]{
+    val res = new Reading{
       val c: c0.type = c0
-      def typeclass = e2
+
+      def typeclassFor[T: this.c.WeakTypeTag]: this.c.universe.Type = c.weakTypeOf[R[T]]
     }.derive[T]
     c0.Expr[R[T]](res)
   }
@@ -130,9 +131,9 @@ object Macros {
                          (implicit e1: c0.WeakTypeTag[T], e2: c0.WeakTypeTag[W[_]]): c0.Expr[W[T]] = {
     import c0.universe._
 
-    val res = new Writing[W]{
+    val res = new Writing{
       val c: c0.type = c0
-      def typeclass = e2
+      def typeclassFor[T: this.c.WeakTypeTag]: this.c.universe.Type = c.weakTypeOf[W[T]]
     }.derive[T]
 //    println(res)
     c0.Expr[W[T]](res)


### PR DESCRIPTION
I'm putting this here as a start of an approach to fix #116 but it isn't yet complete.

It works for pprint but doesn't work for upickle. In upickle, the approach doesn't work because the macros need to work for the path-dependent Reader/Writer types which somehow need to get passed to the macro.
