### PR TITLE
Added support for field names in PPrint

### DIFF
--- a/pprint/shared/src/main/scala/pprint/Core.scala
+++ b/pprint/shared/src/main/scala/pprint/Core.scala
@@ -14,13 +14,15 @@ import acyclic.file
  * @param renames A map used to rename things to more common names, e.g.
  *                renamig `WrappedArray` to `Array` or getting rid of
  *                TupleN *
+ * @param showFieldNames Whether case class field names should be printed
  */
 case class Config(width: Int = Config.defaultMaxWidth,
                   height: Int = Config.defaultLines,
                   depth: Int = 0,
                   indent: Int = Config.defaultIndent,
                   colors: Colors = pprint.Colors.BlackWhite,
-                  renames: Map[String, String] = Config.defaultRenames)
+                  renames: Map[String, String] = Config.defaultRenames,
+                  showFieldNames: Boolean = false)
   extends GenConfig[Config]{
   def deeper = copy(depth = depth + 1)
 

--- a/pprint/shared/src/test/scala/test/pprint/DerivationTests.scala
+++ b/pprint/shared/src/test/scala/test/pprint/DerivationTests.scala
@@ -37,6 +37,13 @@ object DerivationTests extends TestSuite{
 
       Check(ADT0(), "ADT0()")
     }
+    'adtsWithFields {
+      import derive.ADTs._
+      Check(
+        Seq(ADTb(123, "hello world")),
+        """List(ADTb(i = 123, s = "hello world"))"""
+      )(implicitly, PPrintConfig.copy(showFieldNames = true))
+    }
     'sealedHierarchies {
       import derive.DeepHierarchy._
       Check(

--- a/project/repo.scala
+++ b/project/repo.scala
@@ -1,3 +1,3 @@
 package object repo{
-  val version = "0.3.7-SNAPSHOT"
+  val version = "0.3.6.1"
 }


### PR DESCRIPTION
The motivation for this feature is to obtain a more verbose and descriptive representation of objects by also displaying field names. This can be especially useful when logging. Although JSON could be used for that, it is bit more noisy and a less natural description of Scala objects. Also this is legal Scala syntax so objects printed in such a manner could still be parsed and evaluated by Scala. 

```
scala> import pprint.Config.Colors._
import pprint.Config.Colors._

scala> case class Test(name: String, value: Int)
defined class Test

scala> pprint.pprintln(Test("a" * 10, 1))
Test("aaaaaaaaaa", 1)

scala> pprint.pprintln(Test("a" * 10, 1))(implicitly, PPrintConfig.copy(showFieldNames = true))
Test(name = "aaaaaaaaaa", value = 1)

scala> pprint.pprintln(Test("a" * 80, 1))(implicitly, PPrintConfig.copy(showFieldNames = true))
Test(
  name = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
  value = 1
)
```

This is a bit preliminary in that I have added only one test. I can't think if there are any corner cases to consider. Also Scala macros aren't my strong suit. However the changes to the code are very minimal. Looking forward to your feedback.

For full disclosure, I do see one respect in which this change might not be enough for my needs long term: It might be nice in the future to support an annotation on some fields whose name should be omitted in spite `showFieldNames = true`. I already see a few cases where I'd like that feature. Your renaming mechanism could perhaps be extended to address similar issues with field names (Option.x is not very useful). My feeling is that we do not need to address the support for such exceptions as part of this PR; what do you think ?

While reviewing your PR guidelines (those for Ammonite), I notice I haven't added to the documentation. I should do that.

Thanks
