### PR TITLE
Case classes can now also render their field name.

### DIFF
--- a/pprint/shared/src/main/scala/pprint/Core.scala
+++ b/pprint/shared/src/main/scala/pprint/Core.scala
@@ -14,13 +14,16 @@ import acyclic.file
  * @param renames A map used to rename things to more common names, e.g.
  *                renamig `WrappedArray` to `Array` or getting rid of
  *                TupleN *
+ * @param showFieldName Should the field name of a case class be displayed
+                        alongside its value, e.g. `Foo(a = 3)`.
  */
 case class Config(width: Int = Config.defaultMaxWidth,
                   height: Int = Config.defaultLines,
                   depth: Int = 0,
                   indent: Int = Config.defaultIndent,
                   colors: Colors = pprint.Colors.BlackWhite,
-                  renames: Map[String, String] = Config.defaultRenames)
+                  renames: Map[String, String] = Config.defaultRenames,
+                  showFieldName: Boolean = false)
   extends GenConfig[Config]{
   def deeper = copy(depth = depth + 1)
 


### PR DESCRIPTION
Whether the field name should be shown is configured via the `showFieldName` flag in the Config.

Rather than change the Tuple pretty printer I changed the code to derive a targeted pretty printer for each case class.