### PR TITLE
Verify that primary constructors are public and return correct type

### DIFF
--- a/derive/shared/src/main/scala/derive/Derive.scala
+++ b/derive/shared/src/main/scala/derive/Derive.scala
@@ -388,7 +388,7 @@ abstract class Derive[M[_]] extends DeriveApi[M]{
       //tickle the companion members -- Not doing this leads to unexpected runtime behavior
       //I wonder if there is an SI related to this?
       companion.tpe.members.foreach(_ => ())
-      tpe.members.find(x => x.isMethod && x.asMethod.isPrimaryConstructor) match {
+      tpe.members.find(x => x.isMethod && x.asMethod.isPrimaryConstructor && x.asMethod.isPublic && x.asMethod.returnType.typeSymbol == tpe.typeSymbol) match {
         case None => Left("Can't find primary constructor of " + tpe)
         case Some(primaryConstructor) => Right((companion, tpe.typeSymbol.asClass.typeParams, primaryConstructor.asMethod.paramss.flatten))
       }


### PR DESCRIPTION
When trying to unpickle Squants quantities with uPickle, uPickle tries to use the apply methods of the [companion object](https://github.com/typelevel/squants/blob/master/shared/src/main/scala/squants/motion/Velocity.scala#L49) of the quantity type. With Squants, one of these is private and the other does not return the quantity type (it returns a `Try` of it). This PR prevents uPickle from generating an uncompilable `Reader` for such cases by verifying that the apply method is public and the method returns the appropriate type.