### PR TITLE
change default implicit Reader[Map] to use ListMap (keeps order)

### DIFF
--- a/upickle/shared/src/main/scala/upickle/Implicits.scala
+++ b/upickle/shared/src/main/scala/upickle/Implicits.scala
@@ -10,6 +10,8 @@ import scala.language.higherKinds
 import scala.language.experimental.macros
 import java.util.UUID
 
+import scala.collection.immutable.ListMap
+
 
 /**
 * Typeclasses to allow read/writing of all the common
@@ -208,12 +210,12 @@ trait Implicits extends Types with BigDecimalSupport { imp: Generated =>
 
   implicit def MapR[K: R, V: R]: R[Map[K, V]] =
     if (implicitly[R[K]] == implicitly[R[String]])
-      R[Map[K, V]](Internal.validate("Object"){
-        case x: Js.Obj => x.value.map{case (k, v) => (k.asInstanceOf[K], readJs[V](v))}.toMap
+      R[Map[K, V]](Internal.validate("Object") {
+        case x: Js.Obj => x.value.map{case (k, v) => (k.asInstanceOf[K], readJs[V](v))}(collection.breakOut):ListMap[K,V]
       })
     else
       R[Map[K, V]](Internal.validate("Array(n)"){
-        case x: Js.Arr => x.value.map(readJs[(K, V)]).toMap
+        case x: Js.Arr => x.value.map(readJs[(K, V)])(collection.breakOut):ListMap[K,V]
       })
 
   implicit def EitherR[A: R, B: R]: R[Either[A, B]] = R[Either[A, B]](


### PR DESCRIPTION
Default implementation of Reader[Map[K,V]] don't keep order of fields in objects. This is information that  we can keep without trouble (probably). I used similar implementation in my code (mostly scripts).

i used this code to validate this pull request:
```scala
import upickle.default._
import scala.collection.immutable.ListMap
val rest:Map[String, String] = (1 to 100).map {
  r => ("r:" + r.toString, "l:" + r.toString)
}(collection.breakOut):ListMap[String, String]

read[Map[String,String]](write(rest))
``` 
