### PR TITLE
Added benchmarks for GenCodec from AVSystem commons

### DIFF
--- a/bench/src-js/Main.scala
+++ b/bench/src-js/Main.scala
@@ -22,6 +22,7 @@ object Main{
       Common.circeCached(duration)
       Common.upickleDefaultCached(duration)
       Common.upickleLegacyCached(duration)
+      Common.genCodecCached(duration)
       upickleWebDefaultCached(duration)
       upickleWebLegacyCached(duration)
       println()

--- a/bench/src-js/Main.scala
+++ b/bench/src-js/Main.scala
@@ -16,6 +16,7 @@ object Main{
       Common.circe(duration)
       Common.upickleDefault(duration)
       Common.upickleLegacy(duration)
+      Common.genCodec(duration)
       upickleWebDefault(duration)
       upickleWebLegacy(duration)
       Common.playJsonCached(duration)

--- a/bench/src-jvm/Main.scala
+++ b/bench/src-jvm/Main.scala
@@ -41,6 +41,7 @@ object Main{
       Common.circeCached(duration)
       Common.upickleDefaultCached(duration)
       Common.upickleLegacyCached(duration)
+      Common.genCodecCached(duration)
       println()
     }
   }

--- a/bench/src-jvm/Main.scala
+++ b/bench/src-jvm/Main.scala
@@ -37,6 +37,7 @@ object Main{
       Common.circe(duration)
       Common.upickleDefault(duration)
       Common.upickleLegacy(duration)
+      Common.genCodec(duration)
       Common.playJsonCached(duration)
       Common.circeCached(duration)
       Common.upickleDefaultCached(duration)

--- a/bench/src/Common.scala
+++ b/bench/src/Common.scala
@@ -114,7 +114,7 @@ object Common{
   def genCodec(duration: Int) = {
     import com.avsystem.commons.serialization._
 
-    implicit def gc1: GenCodec[ADT[Seq[(Int, Int)], String, A, LL, ADTc, ADT0]] = GenCodec.materialize
+    implicit def gc1: GenCodec[Data] = GenCodec.materialize
     implicit def gc2: GenCodec[A] = GenCodec.materialize
     implicit def gc3: GenCodec[B] = GenCodec.materialize
     implicit def gc4: GenCodec[C] = GenCodec.materialize
@@ -229,7 +229,7 @@ object Common{
   def genCodecCached(duration: Int) = {
     import com.avsystem.commons.serialization._
 
-    implicit lazy val gc1: GenCodec[ADT[Seq[(Int, Int)], String, A, LL, ADTc, ADT0]] = GenCodec.materialize
+    implicit lazy val gc1: GenCodec[Data] = GenCodec.materialize
     implicit lazy val gc2: GenCodec[A] = GenCodec.materialize
     implicit lazy val gc3: GenCodec[B] = GenCodec.materialize
     implicit lazy val gc4: GenCodec[C] = GenCodec.materialize

--- a/bench/src/Common.scala
+++ b/bench/src/Common.scala
@@ -110,6 +110,26 @@ object Common{
       upickle.default.write(_)
     )
   }
+
+  def genCodec(duration: Int) = {
+    import com.avsystem.commons.serialization._
+
+    implicit def gc1: GenCodec[ADT[Seq[(Int, Int)], String, A, LL, ADTc, ADT0]] = GenCodec.materialize
+    implicit def gc2: GenCodec[A] = GenCodec.materialize
+    implicit def gc3: GenCodec[B] = GenCodec.materialize
+    implicit def gc4: GenCodec[C] = GenCodec.materialize
+    implicit def gc5: GenCodec[LL] = GenCodec.materialize
+    implicit def gc6: GenCodec[Node] = GenCodec.materialize
+    implicit def gc7: GenCodec[End.type] = GenCodec.materialize
+    implicit def gc8: GenCodec[ADTc] = GenCodec.materialize
+    implicit def gc9: GenCodec[ADT0] = GenCodec.materialize
+
+    bench(duration)(
+      json.JsonStringInput.read[Data](_),
+      json.JsonStringOutput.write[Data](_)
+    )
+  }
+
   def circeCached(duration: Int) = {
     import io.circe._
     import io.circe.generic.semiauto._
@@ -208,7 +228,8 @@ object Common{
 
   def genCodecCached(duration: Int) = {
     import com.avsystem.commons.serialization._
-        
+
+    implicit lazy val gc1: GenCodec[ADT[Seq[(Int, Int)], String, A, LL, ADTc, ADT0]] = GenCodec.materialize
     implicit lazy val gc2: GenCodec[A] = GenCodec.materialize
     implicit lazy val gc3: GenCodec[B] = GenCodec.materialize
     implicit lazy val gc4: GenCodec[C] = GenCodec.materialize
@@ -217,7 +238,6 @@ object Common{
     implicit lazy val gc7: GenCodec[End.type] = GenCodec.materialize
     implicit lazy val gc8: GenCodec[ADTc] = GenCodec.materialize
     implicit lazy val gc9: GenCodec[ADT0] = GenCodec.materialize
-    implicit lazy val gc1: GenCodec[ADT[Seq[(Int, Int)], String, A, LL, ADTc, ADT0]] = GenCodec.materialize
 
     bench(duration)(
       json.JsonStringInput.read[Data](_),
@@ -238,6 +258,7 @@ object Common{
     assert(stringified == rewritten)
     bench0[Data](duration, stringified)(f1, f2)
   }
+
   def bench0[T](duration: Int, stringified: String)
                (f1: String => T, f2: T => String)
                (implicit name: sourcecode.Name)= {

--- a/bench/src/Common.scala
+++ b/bench/src/Common.scala
@@ -206,6 +206,25 @@ object Common{
     )
   }
 
+  def genCodecCached(duration: Int) = {
+    import com.avsystem.commons.serialization._
+        
+    implicit lazy val gc2: GenCodec[A] = GenCodec.materialize
+    implicit lazy val gc3: GenCodec[B] = GenCodec.materialize
+    implicit lazy val gc4: GenCodec[C] = GenCodec.materialize
+    implicit lazy val gc5: GenCodec[LL] = GenCodec.materialize
+    implicit lazy val gc6: GenCodec[Node] = GenCodec.materialize
+    implicit lazy val gc7: GenCodec[End.type] = GenCodec.materialize
+    implicit lazy val gc8: GenCodec[ADTc] = GenCodec.materialize
+    implicit lazy val gc9: GenCodec[ADT0] = GenCodec.materialize
+    implicit lazy val gc1: GenCodec[ADT[Seq[(Int, Int)], String, A, LL, ADTc, ADT0]] = GenCodec.materialize
+
+    bench(duration)(
+      json.JsonStringInput.read[Data](_),
+      json.JsonStringOutput.write[Data](_)
+    )
+  }
+
   def bench(duration: Int)
            (f1: String => Data, f2: Data => String)
            (implicit name: sourcecode.Name) = {

--- a/build.sc
+++ b/build.sc
@@ -110,12 +110,6 @@ object ujson extends Module{
       ivy"com.fasterxml.jackson.core:jackson-databind:2.9.4"
     )
   }
-
-  object avsCommons extends Cross[AvsCommons]("2.11.11", "2.12.4")
-  class AvsCommons(val crossScalaVersion: String) extends CrossScalaModule{
-    def moduleDeps = Seq(ujson.jvm())
-    def ivyDeps = Agg(ivy"com.avsystem.commons::commons-core:1.26.3")
-  }
 }
 
 trait UpickleModule extends CommonPublishModule{
@@ -201,7 +195,6 @@ object upickle extends Module{
         ujson.circe(),
         ujson.json4s(),
         ujson.play(),
-        ujson.avsCommons(),
       )
       def ivyDeps = super.ivyDeps() ++ bench.jvm.ivyDeps()
     }
@@ -236,8 +229,8 @@ trait BenchModule extends CommonModule{
     ivy"com.typesafe.play::play-json::2.6.7",
     ivy"io.argonaut::argonaut:6.2",
     ivy"org.json4s::json4s-ast:3.5.2",
-    ivy"com.lihaoyi::sourcecode:0.1.4",
-    ivy"com.avsystem.commons::commons-core:1.26.3",
+    ivy"com.lihaoyi::sourcecode::0.1.4",
+    ivy"com.avsystem.commons::commons-core::1.26.3",
   )
 }
 

--- a/build.sc
+++ b/build.sc
@@ -230,7 +230,7 @@ trait BenchModule extends CommonModule{
     ivy"io.argonaut::argonaut:6.2",
     ivy"org.json4s::json4s-ast:3.5.2",
     ivy"com.lihaoyi::sourcecode:0.1.4",
-    ivy"com.avsystem.commons::commons-core:1.26.2-SNAPSHOT",
+    ivy"com.avsystem.commons::commons-core:1.26.2",
   )
 }
 

--- a/build.sc
+++ b/build.sc
@@ -110,6 +110,12 @@ object ujson extends Module{
       ivy"com.fasterxml.jackson.core:jackson-databind:2.9.4"
     )
   }
+
+  object avsCommons extends Cross[AvsCommons]("2.11.11", "2.12.4")
+  class AvsCommons(val crossScalaVersion: String) extends CrossScalaModule{
+    def moduleDeps = Seq(ujson.jvm())
+    def ivyDeps = Agg(ivy"com.avsystem.commons::commons-core:1.26.3")
+  }
 }
 
 trait UpickleModule extends CommonPublishModule{
@@ -195,6 +201,7 @@ object upickle extends Module{
         ujson.circe(),
         ujson.json4s(),
         ujson.play(),
+        ujson.avsCommons(),
       )
       def ivyDeps = super.ivyDeps() ++ bench.jvm.ivyDeps()
     }
@@ -230,7 +237,7 @@ trait BenchModule extends CommonModule{
     ivy"io.argonaut::argonaut:6.2",
     ivy"org.json4s::json4s-ast:3.5.2",
     ivy"com.lihaoyi::sourcecode:0.1.4",
-    ivy"com.avsystem.commons::commons-core:1.26.2",
+    ivy"com.avsystem.commons::commons-core:1.26.3",
   )
 }
 

--- a/build.sc
+++ b/build.sc
@@ -230,6 +230,7 @@ trait BenchModule extends CommonModule{
     ivy"io.argonaut::argonaut:6.2",
     ivy"org.json4s::json4s-ast:3.5.2",
     ivy"com.lihaoyi::sourcecode:0.1.4",
+    ivy"com.avsystem.commons::commons-core:1.26.2-SNAPSHOT",
   )
 }
 


### PR DESCRIPTION
In [AVSystem commons library](https://github.com/AVSystem/scala-commons) we have our own serialization engine, [`GenCodec`](https://github.com/AVSystem/scala-commons/blob/master/docs/GenCodec.md). It is the default serialization used in [Udash framework](https://udash.io/) for client-server RPC. Like uPickle, it avoids any intermediate representations (shapeless `Generic`, JSON AST). We thought it would be interesting to add it to uPickle's benchmarks.

Our own [benchmarks](https://github.com/AVSystem/scala-commons/blob/master/commons-benchmark/jvm/src/main/scala/com/avsystem/commons/ser/JsonSerializationBenchmark.scala) show that `GenCodec` is mostly faster than uPickle, at least on JVM:

```
[info] Benchmark                                  Mode  Cnt        Score       Error  Units
[info] JsonReadingBenchmark.readCCCirce          thrpt   20   501752.517 ± 21563.049  ops/s
[info] JsonReadingBenchmark.readCCGenCodec       thrpt   20   946505.351 ± 34501.429  ops/s
[info] JsonReadingBenchmark.readCCUpickle        thrpt   20   623353.165 ± 15749.794  ops/s
[info] JsonReadingBenchmark.readFoosCirce        thrpt   20     2452.081 ±   106.193  ops/s
[info] JsonReadingBenchmark.readFoosGenCodec     thrpt   20     3232.530 ±    42.733  ops/s
[info] JsonReadingBenchmark.readFoosUpickle      thrpt   20     3003.591 ±    74.450  ops/s
[info] JsonReadingBenchmark.readSHCirce          thrpt   20   259242.384 ±  6019.444  ops/s
[info] JsonReadingBenchmark.readSHGenCodec       thrpt   20   557107.475 ± 10733.433  ops/s
[info] JsonReadingBenchmark.readFlatSHGenCodec   thrpt   20   477547.963 ±  5282.188  ops/s
[info] JsonReadingBenchmark.readSHUpickle        thrpt   20   316055.404 ±  4679.203  ops/s
[info] JsonWritingBenchmark.writeCCCirce         thrpt   20   593690.358 ± 13488.971  ops/s
[info] JsonWritingBenchmark.writeCCGenCodec      thrpt   20  1462496.398 ± 29445.373  ops/s
[info] JsonWritingBenchmark.writeCCUpickle       thrpt   20  1009314.752 ± 23001.344  ops/s
[info] JsonWritingBenchmark.writeFoosCirce       thrpt   20     2610.398 ±    48.496  ops/s
[info] JsonWritingBenchmark.writeFoosGenCodec    thrpt   20     4278.478 ±    35.718  ops/s
[info] JsonWritingBenchmark.writeFoosUpickle     thrpt   20     3296.622 ±    94.771  ops/s
[info] JsonWritingBenchmark.writeSHCirce         thrpt   20   189393.026 ±  3328.417  ops/s
[info] JsonWritingBenchmark.writeSHGenCodec      thrpt   20   791242.582 ± 11599.197  ops/s
[info] JsonWritingBenchmark.writeFlatSHGenCodec  thrpt   20   752330.860 ±  9901.045  ops/s
[info] JsonWritingBenchmark.writeSHUpickle       thrpt   20   274714.996 ±  3681.794  ops/s
```

For ScalaJS (Chrome), there are some benchmarks that uPickle wins, but in most of them `GenCodec` remains the fastest:

![image](https://user-images.githubusercontent.com/1022675/38021719-ed03b240-327d-11e8-8f78-41fa21b53bc2.png)

And here are some results of running uPickle benchmarks with `GenCodec`:

```
RUN JVM: 25000

ujsonAst Read 2275394
ujsonAst Write 4113811
playJsonAst Read 2822015
playJsonAst Write 3454749
uJsonPlayJsonAst Read 1862602
uJsonPlayJsonAst Write 4600767
circeJsonAst Read 6270370
circeJsonAst Write 5383004
uJsonCirceJsonAst Read 2511308
uJsonCirceJsonAst Write 2727383
argonautJsonAst Read 3027997
argonautJsonAst Write 2506043
uJsonArgonautJsonAst Read 1723680
uJsonArgonautJsonAst Write 1719835
json4sJsonAst Read 3065544
json4sJsonAst Write 1261774
uJsonJson4sJsonAst Read 2607470
uJsonJson4sJsonAst Write 4066699
jacksonModuleScala Read 1497321
jacksonModuleScala Write 10882299
playJson Read 701251
playJson Write 1120857
circe Read 1888165
circe Write 1846813
upickleDefault Read 2334245
upickleDefault Write 3127661
upickleLegacy Read 1888988
upickleLegacy Write 2312430
genCodec Read 4353514
genCodec Write 4947093
playJsonCached Read 873551
playJsonCached Write 1398708
circeCached Read 2363184
circeCached Write 2370771
upickleDefaultCached Read 2876645
upickleDefaultCached Write 4028048
upickleLegacyCached Read 3201907
upickleLegacyCached Write 4068578
genCodecCached Read 4986976
genCodecCached Write 5478475

RUN JS: 25000

rawJsonParseSerialize Read 4117135
rawJsonParseSerialize Write 5134118
playJson Read 75299
playJson Write 145167
circe Read 87523
circe Write 303473
upickleDefault Read 307722
upickleDefault Write 707835
upickleLegacy Read 266975
upickleLegacy Write 600509
genCodec Read 500374
genCodec Write 976660
upickleWebDefault Read 361174
upickleWebDefault Write 590451
upickleWebLegacy Read 336934
upickleWebLegacy Write 546596
playJsonCached Read 95955
playJsonCached Write 210202
circeCached Read 105512
circeCached Write 494419
upickleDefaultCached Read 443684
upickleDefaultCached Write 1211865
upickleLegacyCached Read 405577
upickleLegacyCached Write 1158368
genCodecCached Read 771965
genCodecCached Write 2058078
upickleWebDefaultCached Read 676215
upickleWebDefaultCached Write 1117686
upickleWebLegacyCached Read 620765
upickleWebLegacyCached Write 1021251
```