### PR TITLE
Reformat the code of ujson.

### DIFF
--- a/ujson/src/ujson/AstTransformer.scala
+++ b/ujson/src/ujson/AstTransformer.scala
@@ -2,7 +2,7 @@ package ujson
 
 import scala.collection.generic.CanBuildFrom
 
-trait AstTransformer[I] extends Transformer[I] with ujson.Visitor[I, I]{
+trait AstTransformer[I] extends Transformer[I] with ujson.Visitor[I, I] {
   def transformArray[T](f: Visitor[_, T], items: TraversableOnce[I]) = {
     val ctx = f.visitArray(-1).narrow
     for(item <- items) ctx.visitValue(transform(item, ctx.subVisitor), -1)
@@ -10,7 +10,7 @@ trait AstTransformer[I] extends Transformer[I] with ujson.Visitor[I, I]{
   }
   def transformObject[T](f: Visitor[_, T], items: TraversableOnce[(String, I)]) = {
     val ctx = f.visitObject(-1).narrow
-    for(kv <- items) {
+    for (kv <- items) {
       ctx.visitKey(kv._1, -1)
       ctx.visitValue(transform(kv._2, ctx.subVisitor), -1)
     }
@@ -18,7 +18,7 @@ trait AstTransformer[I] extends Transformer[I] with ujson.Visitor[I, I]{
   }
 
   class AstObjVisitor[T](build: T => I)
-                        (implicit cbf: CanBuildFrom[Nothing, (String, I), T])extends ObjVisitor[I, I] {
+                        (implicit cbf: CanBuildFrom[Nothing, (String, I), T]) extends ObjVisitor[I, I] {
 
     private[this] var key: String = null
     private[this] val vs = cbf.apply()
@@ -30,7 +30,7 @@ trait AstTransformer[I] extends Transformer[I] with ujson.Visitor[I, I]{
     def visitEnd(index: Int) = build(vs.result)
   }
   class AstArrVisitor[T[_]](build: T[I] => I)
-                           (implicit cbf: CanBuildFrom[Nothing, I, T[I]]) extends ArrVisitor[I, I]{
+                           (implicit cbf: CanBuildFrom[Nothing, I, T[I]]) extends ArrVisitor[I, I] {
     def subVisitor = AstTransformer.this
     private[this] val vs = cbf.apply()
     def visitValue(v: I, index: Int): Unit = vs += v

--- a/ujson/src/ujson/AsyncParser.scala
+++ b/ujson/src/ujson/AsyncParser.scala
@@ -96,7 +96,7 @@ final class AsyncParser[J] protected[ujson](
   final def finish(facade: Visitor[_, J]): Either[ParsingFailedException, Seq[J]] = {
     done = true
     try churn(facade)
-    catch{case e: ParsingFailedException => Left(e)}
+    catch { case e: ParsingFailedException => Left(e) }
   }
 
   protected[this] final def resizeIfNecessary(need: Int): Unit = {

--- a/ujson/src/ujson/ByteArrayParser.scala
+++ b/ujson/src/ujson/ByteArrayParser.scala
@@ -33,6 +33,6 @@ final class ByteArrayParser[J](src: Array[Byte], start: Int = 0, limit: Int = 0)
   protected[this] final def atEof(i: Int) = i >= limit
 }
 
-object ByteArrayParser extends Transformer[Array[Byte]]{
+object ByteArrayParser extends Transformer[Array[Byte]] {
   def transform[T](j: Array[Byte], f: Visitor[_, T]) = new ByteArrayParser(j, 0, j.length).parse(f)
 }

--- a/ujson/src/ujson/ByteBasedParser.scala
+++ b/ujson/src/ujson/ByteBasedParser.scala
@@ -103,9 +103,8 @@ trait ByteBasedParser[J] extends Parser[J] {
     if (k != -1) {
       val s = at(i + 1, k - 1)
       (s, k)
-    }else{
+    } else {
       parseStringComplex(i)
-
     }
   }
 }

--- a/ujson/src/ujson/ByteBufferParser.scala
+++ b/ujson/src/ujson/ByteBufferParser.scala
@@ -41,6 +41,6 @@ final class ByteBufferParser[J](src: ByteBuffer) extends SyncParser[J] with Byte
   protected[this] final def atEof(i: Int) = i >= limit
 }
 
-object ByteBufferParser extends Transformer[ByteBuffer]{
+object ByteBufferParser extends Transformer[ByteBuffer] {
   def transform[T](j: ByteBuffer, f: Visitor[_, T]) = new ByteBufferParser(j).parse(f)
 }

--- a/ujson/src/ujson/ChannelParser.scala
+++ b/ujson/src/ujson/ChannelParser.scala
@@ -5,23 +5,23 @@ import java.lang.Integer.{bitCount, highestOneBit}
 import java.nio.ByteBuffer
 import java.nio.channels.ReadableByteChannel
 
-object FileParser extends Transformer[java.io.File]{
+object FileParser extends Transformer[java.io.File] {
   def transform[T](j: java.io.File, f: Visitor[_, T]) = PathParser.transform(j.toPath, f)
 }
 
-object PathParser extends Transformer[java.nio.file.Path]{
+object PathParser extends Transformer[java.nio.file.Path] {
   def transform[T](j: java.nio.file.Path, f: Visitor[_, T]) = {
-    if (java.nio.file.Files.size(j) > ChannelParser.ParseAsStringThreshold){
+    if (java.nio.file.Files.size(j) > ChannelParser.ParseAsStringThreshold) {
       val channel = java.nio.file.Files.newByteChannel(j)
       try new ChannelParser(channel, ChannelParser.DefaultBufferSize).parse(f)
       finally channel.close()
-    }else{
+    } else {
       ByteArrayParser.transform(java.nio.file.Files.readAllBytes(j), f)
     }
   }
 }
 
-object ChannelParser extends Transformer[ReadableByteChannel]{
+object ChannelParser extends Transformer[ReadableByteChannel] {
   def transform[T](j: ReadableByteChannel, f: Visitor[_, T]) = {
     new ChannelParser(j, DefaultBufferSize).parse(f)
   }

--- a/ujson/src/ujson/CharSequenceParser.scala
+++ b/ujson/src/ujson/CharSequenceParser.scala
@@ -17,6 +17,6 @@ private[ujson] final class CharSequenceParser[J](cs: CharSequence) extends SyncP
   final def close() = ()
 }
 
-object CharSequenceParser extends Transformer[CharSequence]{
+object CharSequenceParser extends Transformer[CharSequence] {
   def transform[T](j: CharSequence, f: Visitor[_, T]) = new CharSequenceParser(j).parse(f)
 }

--- a/ujson/src/ujson/Js.scala
+++ b/ujson/src/ujson/Js.scala
@@ -14,7 +14,7 @@ sealed trait Js extends Transformable {
     * Returns the `String` value of this [[Js.Value]], fails if it is not
     * a [[Js.Str]]
     */
-  def str = this match{
+  def str = this match {
     case Js.Str(value) => value
     case _ => throw Js.InvalidData(this, "Expected Js.Str")
   }
@@ -22,7 +22,7 @@ sealed trait Js extends Transformable {
     * Returns the key/value map of this [[Js.Value]], fails if it is not
     * a [[Js.Obj]]
     */
-  def obj = this match{
+  def obj = this match {
     case Js.Obj(value) => value
     case _ => throw Js.InvalidData(this, "Expected Js.Obj")
   }
@@ -30,7 +30,7 @@ sealed trait Js extends Transformable {
     * Returns the elements of this [[Js.Value]], fails if it is not
     * a [[Js.Arr]]
     */
-  def arr = this match{
+  def arr = this match {
     case Js.Arr(value) => value
     case _ => throw Js.InvalidData(this, "Expected Js.Arr")
   }
@@ -38,7 +38,7 @@ sealed trait Js extends Transformable {
     * Returns the `Double` value of this [[Js.Value]], fails if it is not
     * a [[Js.Num]]
     */
-  def num = this match{
+  def num = this match {
     case Js.Num(value) => value
     case _ => throw Js.InvalidData(this, "Expected Js.Num")
   }
@@ -46,7 +46,7 @@ sealed trait Js extends Transformable {
     * Returns the `Boolean` value of this [[Js.Value]], fails if it is not
     * a [[Js.Bool]]
     */
-  def bool = this match{
+  def bool = this match {
     case Js.Bool(value) => value
     case _ => throw Js.InvalidData(this, "Expected Js.Bool")
   }
@@ -74,17 +74,17 @@ sealed trait Js extends Transformable {
 * we don't use so we don't pull in the bulk of Spire) and the Javascript
 * JSON AST.
 */
-object Js extends AstTransformer[Js]{
-  sealed trait Selector{
+object Js extends AstTransformer[Js] {
+  sealed trait Selector {
     def apply(x: Js.Value): Js.Value
     def update(x: Js.Value, y: Js.Value): Unit
   }
-  object Selector{
-    implicit class IntSelector(i: Int) extends Selector{
+  object Selector {
+    implicit class IntSelector(i: Int) extends Selector {
       def apply(x: Js.Value): Js.Value = x.arr(i)
       def update(x: Js.Value, y: Js.Value) = x.arr(i) = y
     }
-    implicit class StringSelector(i: String) extends Selector{
+    implicit class StringSelector(i: String) extends Selector {
       def apply(x: Js.Value): Js.Value = x.obj(i)
       def update(x: Js.Value, y: Js.Value) = x.obj(i) = y
     }
@@ -92,7 +92,7 @@ object Js extends AstTransformer[Js]{
 
   case class Str(value: String) extends Value
   case class Obj(value: mutable.LinkedHashMap[String, Value]) extends Value
-  object Obj{
+  object Obj {
     implicit def from(items: TraversableOnce[(String, Value)]): Obj = {
       Obj(mutable.LinkedHashMap(items.toSeq:_*))
     }
@@ -100,27 +100,27 @@ object Js extends AstTransformer[Js]{
   }
   case class Arr(value: ArrayBuffer[Value]) extends Value
 
-  object Arr{
+  object Arr {
     implicit def from[T <% Js.Value](items: TraversableOnce[T]): Arr =
       Arr(items.map(x => x: Js.Value).to[mutable.ArrayBuffer])
 
     def apply(items: Value*): Arr = Arr(items.to[mutable.ArrayBuffer])
   }
   case class Num(value: Double) extends Value
-  sealed abstract class Bool extends Value{
+  sealed abstract class Bool extends Value {
     def value: Boolean
   }
-  object Bool{
+  object Bool {
     def apply(value: Boolean): Bool = if (value) True else False
     def unapply(bool: Bool): Option[Boolean] = Some(bool.value)
   }
-  case object False extends Bool{
+  case object False extends Bool {
     def value = false
   }
-  case object True extends Bool{
+  case object True extends Bool {
     def value = true
   }
-  case object Null extends Value{
+  case object Null extends Value {
     def value = null
   }
 
@@ -141,7 +141,7 @@ object Js extends AstTransformer[Js]{
   
   type Value = Js
   def transform[T](j: Js.Value, f: ujson.Visitor[_, T]): T = {
-    j match{
+    j match {
       case Js.Null => f.visitNull(-1)
       case Js.True => f.visitTrue(-1)
       case Js.False => f.visitFalse(-1)
@@ -182,7 +182,6 @@ object Js extends AstTransformer[Js]{
     *             This could be the entire blob, or it could be some subtree.
     * @param msg Human-readable text saying what went wrong
     */
-  case class InvalidData(data: Js.Value, msg: String)
-    extends Exception(s"$msg (data: $data)")
+  case class InvalidData(data: Js.Value, msg: String) extends Exception(s"$msg (data: $data)")
 }
 

--- a/ujson/src/ujson/Parser.scala
+++ b/ujson/src/ujson/Parser.scala
@@ -228,7 +228,7 @@ abstract class Parser[J] {
         }
         c = at(j)
       }
-      if(j0 == j) die(i, "expected digit")
+      if (j0 == j) die(i, "expected digit")
     }
 
     if (c == 'e' || c == 'E') {
@@ -244,7 +244,6 @@ abstract class Parser[J] {
       while ('0' <= c && c <= '9') {
         j += 1
         if (atEof(j)) {
-
           return (facade.visitNum(at(i, j), decIndex, expIndex, i), j)
         }
         c = at(j)

--- a/ujson/src/ujson/Renderer.scala
+++ b/ujson/src/ujson/Renderer.scala
@@ -10,7 +10,7 @@ case class BytesRenderer(indent: Int = -1)
   extends BaseRenderer(new BytesRenderer.BytesWriter(), indent){
 }
 
-object BytesRenderer{
+object BytesRenderer {
   class BytesWriter(out: java.io.ByteArrayOutputStream = new ByteArrayOutputStream())
     extends java.io.OutputStreamWriter(out){
     def toBytes = {
@@ -28,7 +28,7 @@ case class Renderer(out: java.io.Writer,
 
 class BaseRenderer[T <: java.io.Writer]
                   (out: T,
-                   indent: Int = -1) extends ujson.Visitor[T, T]{
+                   indent: Int = -1) extends ujson.Visitor[T, T] {
   var depth: Int = 0
   val colonSnippet = if (indent == -1) ":" else ": "
 
@@ -122,7 +122,6 @@ class BaseRenderer[T <: java.io.Writer]
     flushBuffer()
     if (s == null) out.append("null")
     else Renderer.escape(out, s, true)
-
     out
   }
 

--- a/ujson/src/ujson/StringParser.scala
+++ b/ujson/src/ujson/StringParser.scala
@@ -24,6 +24,6 @@ private[ujson] final class StringParser[J](s: String) extends SyncParser[J] with
   final def close() = ()
 }
 
-object StringParser extends Transformer[String]{
+object StringParser extends Transformer[String] {
   def transform[T](j: String, f: Visitor[_, T]) = new StringParser(j).parse(f)
 }

--- a/ujson/src/ujson/Transformable.scala
+++ b/ujson/src/ujson/Transformable.scala
@@ -8,7 +8,7 @@ abstract class Transformable {
 }
 
 object Transformable {
-  case class fromTransformer[T](t: T, w: Transformer[T]) extends Transformable{
+  case class fromTransformer[T](t: T, w: Transformer[T]) extends Transformable {
     def transform[T](f: ujson.Visitor[_, T]): T = {
       w.transform(t, f)
     }

--- a/ujson/src/ujson/Visitor.scala
+++ b/ujson/src/ujson/Visitor.scala
@@ -69,13 +69,13 @@ sealed trait ObjArrVisitor[-J, +T] {
   def narrow = this.asInstanceOf[ObjArrVisitor[Any, T]]
 
 }
-trait ObjVisitor[-J, +T] extends ObjArrVisitor[J, T]{
+trait ObjVisitor[-J, +T] extends ObjArrVisitor[J, T] {
   def visitKey(s: CharSequence, index: Int): Unit
   def isObj = true
   override def narrow = this.asInstanceOf[ObjVisitor[Any, T]]
 }
 
-trait ArrVisitor[-J, +T] extends ObjArrVisitor[J, T]{
+trait ArrVisitor[-J, +T] extends ObjArrVisitor[J, T] {
   def isObj = false
   override def narrow = this.asInstanceOf[ArrVisitor[Any, T]]
 }

--- a/ujson/src/ujson/package.scala
+++ b/ujson/src/ujson/package.scala
@@ -1,4 +1,4 @@
-package object ujson{
+package object ujson {
   def transform[T](t: Transformable, v: Visitor[_, T]) = t.transform(v)
 
   def read(s: Transformable): Js.Value = transform(s, Js)


### PR DESCRIPTION
I notice that some codes in `ujson` project owns the following style:
```
trait AstTransformer[I] extends Transformer[I] with ujson.Visitor[I, I]{ 
// there is no whitespace between "Visitor[I, I]" and "{"
```
So I add a whitespace before `{`

```
trait AstTransformer[I] extends Transformer[I] with ujson.Visitor[I, I] {
```