### PR TITLE
Fix: AsyncParser single comma bug

### DIFF
--- a/ujson/src/ujson/ByteArrayParser.scala
+++ b/ujson/src/ujson/ByteArrayParser.scala
@@ -22,7 +22,7 @@ final class ByteArrayParser[J](src: Array[Byte], start: Int = 0, limit: Int = 0)
 
   protected[this] final def close() {}
   protected[this] final def reset(i: Int): Int = i
-  protected[this] final def checkpoint(state: Int, i: Int, stack: List[ObjArrVisitor[_, J]]) {}
+  protected[this] final def checkpoint(state: Int, i: Int, stack: List[ObjArrVisitor[_, J]], path: List[Any]) {}
   protected[this] final def byte(i: Int): Byte = src(i + start)
   protected[this] final def at(i: Int): Char = src(i + start).toChar
 

--- a/ujson/src/ujson/ByteBufferParser.scala
+++ b/ujson/src/ujson/ByteBufferParser.scala
@@ -25,7 +25,7 @@ final class ByteBufferParser[J](src: ByteBuffer) extends SyncParser[J] with Byte
 
   protected[this] final def close() { src.position(src.limit) }
   protected[this] final def reset(i: Int): Int = i
-  protected[this] final def checkpoint(state: Int, i: Int, stack: List[ObjArrVisitor[_, J]]) {}
+  protected[this] final def checkpoint(state: Int, i: Int, stack: List[ObjArrVisitor[_, J]], path: List[Any]) {}
   protected[this] final def byte(i: Int): Byte = src.get(i + start)
   protected[this] final def at(i: Int): Char = src.get(i + start).toChar
 

--- a/ujson/src/ujson/ChannelParser.scala
+++ b/ujson/src/ujson/ChannelParser.scala
@@ -131,7 +131,7 @@ final class ChannelParser[J](ch: ReadableByteChannel, bufferSize: Int) extends S
       i
     }
 
-  protected[this] final def checkpoint(state: Int, i: Int, stack: List[ObjArrVisitor[_, J]]): Unit = ()
+  protected[this] final def checkpoint(state: Int, i: Int, stack: List[ObjArrVisitor[_, J]], path: List[Any]): Unit = ()
 
   /**
    * This is a specialized accessor for the case where our underlying

--- a/ujson/src/ujson/CharSequenceParser.scala
+++ b/ujson/src/ujson/CharSequenceParser.scala
@@ -10,7 +10,7 @@ private[ujson] final class CharSequenceParser[J](cs: CharSequence) extends SyncP
   final def column(i: Int) = i
   final def newline(i: Int) { line += 1 }
   final def reset(i: Int): Int = i
-  final def checkpoint(state: Int, i: Int, stack: List[ObjArrVisitor[_, J]]): Unit = ()
+  final def checkpoint(state: Int, i: Int, stack: List[ObjArrVisitor[_, J]], path: List[Any]): Unit = ()
   final def at(i: Int): Char = Platform.charAt(cs, i)
   final def at(i: Int, j: Int): CharSequence = cs.subSequence(i, j)
   final def atEof(i: Int) = i == cs.length

--- a/ujson/src/ujson/Parser.scala
+++ b/ujson/src/ujson/Parser.scala
@@ -67,7 +67,7 @@ abstract class Parser[J] {
    * The checkpoint() method is used to allow some parsers to store
    * their progress.
    */
-  protected[this] def checkpoint(state: Int, i: Int, stack: List[ObjArrVisitor[_, J]]): Unit
+  protected[this] def checkpoint(state: Int, i: Int, stack: List[ObjArrVisitor[_, J]], path: List[Any]): Unit
 
   /**
    * Should be called when parsing is finished.
@@ -373,6 +373,9 @@ abstract class Parser[J] {
    * worse than manually constructed if/else statements or something
    * else. Also, it may be possible to reorder some cases for speed
    * improvements.
+   *
+   * @param j index/position in the source json
+   * @param path the json path in the tree
    */
   @tailrec
   protected[this] final def rparse(state: Int,
@@ -380,7 +383,7 @@ abstract class Parser[J] {
                                    stack: List[ObjArrVisitor[_, J]],
                                    path: List[Any]) : (J, Int) = {
     val i = reset(j)
-    checkpoint(state, i, stack)
+    checkpoint(state, i, stack, path)
     def facade: Visitor[_, J] = stack.head.subVisitor.asInstanceOf[Visitor[_, J]]
     val c = at(i)
 

--- a/ujson/src/ujson/StringParser.scala
+++ b/ujson/src/ujson/StringParser.scala
@@ -17,7 +17,7 @@ private[ujson] final class StringParser[J](s: String) extends SyncParser[J] with
   final def column(i: Int) = i
   final def newline(i: Int) { line += 1 }
   final def reset(i: Int): Int = i
-  final def checkpoint(state: Int, i: Int, stack: List[ObjArrVisitor[_, J]]): Unit = ()
+  final def checkpoint(state: Int, i: Int, stack: List[ObjArrVisitor[_, J]], path: List[Any]): Unit = ()
   final def at(i: Int): Char = Platform.charAt(s, i)
   final def at(i: Int, j: Int): CharSequence = s.substring(i, j)
   final def atEof(i: Int) = i == s.length


### PR DESCRIPTION
AsyncParser doesn't like absorbing single commas.
```
[info] java.util.NoSuchElementException: head of empty list
[info] 	at scala.collection.immutable.Nil$.head(List.scala:431)
[info] 	at scala.collection.immutable.Nil$.head(List.scala:428)
[info] 	at ujson.Parser.rparse(Parser.scala:459)
[info] 	at ujson.AsyncParser.churn(AsyncParser.scala:214)
[info] 	at ujson.AsyncParser.absorb(AsyncParser.scala:87)
[info] 	at ujson.AsyncParser.absorb(AsyncParser.scala:91)
```