### PR TITLE
More efficient serialization of escaped characters

### DIFF
--- a/ujson/src/ujson/Renderer.scala
+++ b/ujson/src/ujson/Renderer.scala
@@ -153,11 +153,15 @@ object Renderer {
         case '\r' => sb.append("\\r")
         case '\t' => sb.append("\\t")
         case c =>
-          if (c < ' ' || (c > '~' && unicode)) sb.append("\\u%04x" format c.toInt)
-          else sb.append(c)
+          if (c < ' ' || (c > '~' && unicode)) {
+            sb.append("\\u").append(toHex((c >> 12) & 15)).append(toHex((c >> 8) & 15))
+              .append(toHex((c >> 4) & 15)).append(toHex(c & 15))
+          } else sb.append(c)
       }
       i += 1
     }
     sb.append('"')
   }
+
+  private def toHex(nibble: Int): Char = (nibble + (if (nibble >= 10) 87 else 48)).toChar
 }


### PR DESCRIPTION
Below are sources of the benchmark and its results:
https://github.com/plokhotnyuk/jsoniter-scala/blob/master/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/StringOfEscapedCharsBenchmark.scala#L103

Before:
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                                         (size)   Mode  Cnt       Score        Error  Units
[info] StringOfEscapedCharsBenchmark.writeUPickle                           128  thrpt   15   18715.294 ±    524.975  ops/s
[info] StringOfEscapedCharsBenchmark.writeUPickle:CPI                       128  thrpt    3       0.347 ±      0.047   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:L1-dcache-load-misses     128  thrpt    3    1926.363 ±    630.706   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:L1-dcache-loads           128  thrpt    3  178477.026 ±  56114.844   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:L1-dcache-stores          128  thrpt    3   88879.523 ±  60573.726   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:L1-icache-load-misses     128  thrpt    3    1483.211 ±  22984.154   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:LLC-load-misses           128  thrpt    3       6.037 ±     35.212   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:LLC-loads                 128  thrpt    3      22.214 ±    130.816   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:LLC-store-misses          128  thrpt    3      24.458 ±     56.566   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:LLC-stores                128  thrpt    3     315.023 ±    840.669   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:branch-misses             128  thrpt    3      32.906 ±    278.139   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:branches                  128  thrpt    3  105975.242 ±  97108.628   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:cycles                    128  thrpt    3  200402.089 ±  98343.281   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:dTLB-load-misses          128  thrpt    3       4.239 ±     56.416   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:dTLB-loads                128  thrpt    3  179986.593 ±  56590.837   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:dTLB-store-misses         128  thrpt    3       0.353 ±      0.900   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:dTLB-stores               128  thrpt    3   88353.881 ±  65996.538   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:iTLB-load-misses          128  thrpt    3       1.332 ±      4.944   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:iTLB-loads                128  thrpt    3       5.051 ±     33.820   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:instructions              128  thrpt    3  578026.604 ± 349071.110   #/op
```

After:
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                                         (size)   Mode  Cnt      Score      Error  Units
[info] StringOfEscapedCharsBenchmark.writeUPickle                           128  thrpt   15  82759.254 ±  160.759  ops/s
[info] StringOfEscapedCharsBenchmark.writeUPickle:CPI                       128  thrpt    3      0.832 ±    0.131   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:L1-dcache-load-misses     128  thrpt    3     79.525 ±   46.970   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:L1-dcache-loads           128  thrpt    3  15002.529 ± 1773.783   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:L1-dcache-stores          128  thrpt    3   8804.176 ±  286.777   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:L1-icache-load-misses     128  thrpt    3      4.828 ±   44.144   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:LLC-load-misses           128  thrpt    3      1.162 ±    3.714   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:LLC-loads                 128  thrpt    3      2.554 ±    8.914   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:LLC-store-misses          128  thrpt    3     21.347 ±    5.595   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:LLC-stores                128  thrpt    3     38.144 ±   28.481   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:branch-misses             128  thrpt    3     12.461 ±   38.424   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:branches                  128  thrpt    3  10129.952 ±  407.203   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:cycles                    128  thrpt    3  45900.350 ± 1669.690   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:dTLB-load-misses          128  thrpt    3      2.029 ±    1.304   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:dTLB-loads                128  thrpt    3  15011.025 ± 1118.315   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:dTLB-store-misses         128  thrpt    3      0.638 ±   10.015   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:dTLB-stores               128  thrpt    3   8784.672 ±  561.290   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:iTLB-load-misses          128  thrpt    3      1.256 ±   35.457   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:iTLB-loads                128  thrpt    3      0.388 ±    2.149   #/op
[info] StringOfEscapedCharsBenchmark.writeUPickle:instructions              128  thrpt    3  55202.610 ± 8626.674   #/op
```