### PR TITLE
Fix dead code warning on write macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: scala
 scala:
-  - 2.11.11
-  - 2.12.4
+  - 2.11.12
+  - 2.12.6
 
 script:
 - curl -L -o ~/bin/mill https://github.com/lihaoyi/mill/releases/download/0.2.7/0.2.7 && chmod +x ~/bin/mill

--- a/upickle/src/upickle/internal/Macros.scala
+++ b/upickle/src/upickle/internal/Macros.scala
@@ -348,14 +348,8 @@ object Macros {
       def write(i: Int) = {
         val snippet = q"""
           ctx.visitKey(${c.prefix}.objectAttributeKeyWriteMap(${mappedArgs(i)}), -1)
-          val w = implicitly[${c.prefix}.Writer[${argTypes(i)}]].asInstanceOf[${c.prefix}.Writer[Any]]
-          ctx.visitValue(
-            w.write(
-              ctx.subVisitor.asInstanceOf[ujson.Visitor[Any, Nothing]],
-              v.${TermName(rawArgs(i))}
-            ),
-            -1
-          )
+          val w = implicitly[${c.prefix}.Writer[${argTypes(i)}]]
+          ctx.narrow.visitValue(w.write(ctx.subVisitor, v.${TermName(rawArgs(i))}), -1)
         """
         if (!hasDefaults(i)) snippet
         else q"""if (v.${TermName(rawArgs(i))} != ${defaults(i)}) $snippet"""


### PR DESCRIPTION
Fixes #236.

I'm not fully sure why the macro was previously casting the writer and the visitor using `asInstanceOf`, or why the dead code warnings were happening, but everything seems to be working as expected with this change.