### PR TITLE
Add 2.13.0-M5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 sudo: false
 language: scala
-scala:
-  - 2.11.12
-  - 2.12.7
+
+before_install:
+  - curl -L -o ~/bin/mill https://github.com/lihaoyi/mill/releases/download/0.3.4/0.3.4 && chmod +x ~/bin/mill
 
 script:
-- curl -L -o ~/bin/mill https://github.com/lihaoyi/mill/releases/download/0.3.4/0.3.4 && chmod +x ~/bin/mill
 - mill __[$TRAVIS_SCALA_VERSION].test
+
+jobs:
+  include:
+    - scala: 2.11.12
+    - scala: 2.12.7
+    - scala: 2.13.0-M5
+      script: for proj in core ujson upack upickle; do for pf in jvm js; do mill $proj.$pf[$TRAVIS_SCALA_VERSION].test || exit 1; done || exit 1; done

--- a/build.sc
+++ b/build.sc
@@ -27,7 +27,7 @@ trait CommonPublishModule extends CommonModule with PublishModule with CrossScal
 }
 
 trait CommonTestModule extends CommonModule with TestModule{
-  def ivyDeps = Agg(ivy"com.lihaoyi::utest::0.6.4", ivy"com.lihaoyi::acyclic:0.1.5")
+  def ivyDeps = Agg(ivy"com.lihaoyi::utest::0.6.6", ivy"com.lihaoyi::acyclic:0.1.8")
   def testFrameworks = Seq("upickle.core.UTestFramework")
 }
 trait CommonJvmModule extends CommonPublishModule{
@@ -70,7 +70,7 @@ object implicits extends Module {
 
   trait ImplicitsModule extends CommonPublishModule{
     def compileIvyDeps = Agg(
-      ivy"com.lihaoyi::acyclic:0.1.5",
+      ivy"com.lihaoyi::acyclic:0.1.8",
       ivy"org.scala-lang:scala-reflect:${scalaVersion()}"
     )
     def generatedSources = T{
@@ -160,8 +160,8 @@ object ujson extends Module{
     def artifactName = "ujson"
     trait JawnTestModule extends CommonTestModule{
       def ivyDeps = Agg(
-        ivy"org.scalatest::scalatest::3.0.3",
-        ivy"org.scalacheck::scalacheck::1.13.5"
+        ivy"org.scalatest::scalatest::3.0.7",
+        ivy"org.scalacheck::scalacheck::1.14.0"
       )
       def testFrameworks = Seq("org.scalatest.tools.Framework")
     }
@@ -185,7 +185,7 @@ object ujson extends Module{
     def artifactName = "ujson-argonaut"
     def platformSegment = "jvm"
     def moduleDeps = Seq(ujson.jvm())
-    def ivyDeps = Agg(ivy"io.argonaut::argonaut:6.2")
+    def ivyDeps = Agg(ivy"io.argonaut::argonaut:6.2.3")
   }
   object json4s extends Cross[Json4sModule]("2.11.12", "2.12.7")
   class Json4sModule(val crossScalaVersion: String) extends CommonPublishModule{
@@ -193,8 +193,8 @@ object ujson extends Module{
     def platformSegment = "jvm"
     def moduleDeps = Seq(ujson.jvm())
     def ivyDeps = Agg(
-      ivy"org.json4s::json4s-ast:3.5.2",
-      ivy"org.json4s::json4s-native:3.5.2"
+      ivy"org.json4s::json4s-ast:3.6.5",
+      ivy"org.json4s::json4s-native:3.6.5"
     )
   }
 
@@ -203,7 +203,7 @@ object ujson extends Module{
     def artifactName = "ujson-circe"
     def platformSegment = "jvm"
     def moduleDeps = Seq(ujson.jvm())
-    def ivyDeps = Agg(ivy"io.circe::circe-parser:0.9.1")
+    def ivyDeps = Agg(ivy"io.circe::circe-parser:0.11.1")
   }
 
   object play extends Cross[PlayModule]("2.11.12", "2.12.7")
@@ -212,7 +212,7 @@ object ujson extends Module{
     def platformSegment = "jvm"
     def moduleDeps = Seq(ujson.jvm())
     def ivyDeps = Agg(
-      ivy"com.typesafe.play::play-json:2.6.9",
+      ivy"com.typesafe.play::play-json:2.7.2",
       ivy"com.fasterxml.jackson.core:jackson-databind:2.9.4"
     )
   }
@@ -221,10 +221,10 @@ object ujson extends Module{
 trait UpickleModule extends CommonPublishModule{
   def artifactName = "upickle"
   def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++ Agg(
-    ivy"com.lihaoyi::acyclic:0.1.5"
+    ivy"com.lihaoyi::acyclic:0.1.8"
   )
   def compileIvyDeps = Agg(
-    ivy"com.lihaoyi::acyclic:0.1.5",
+    ivy"com.lihaoyi::acyclic:0.1.8",
     ivy"org.scala-lang:scala-reflect:${scalaVersion()}",
     ivy"org.scala-lang:scala-compiler:${scalaVersion()}"
   )
@@ -276,13 +276,13 @@ trait BenchModule extends CommonModule{
   def scalaVersion = "2.12.7"
   def millSourcePath = build.millSourcePath / "bench"
   def ivyDeps = Agg(
-    ivy"io.circe::circe-core::0.9.1",
-    ivy"io.circe::circe-generic::0.9.1",
-    ivy"io.circe::circe-parser::0.9.1",
-    ivy"com.typesafe.play::play-json::2.6.7",
-    ivy"io.argonaut::argonaut:6.2",
-    ivy"org.json4s::json4s-ast:3.5.2",
-    ivy"com.lihaoyi::sourcecode::0.1.4",
+    ivy"io.circe::circe-core::0.11.1",
+    ivy"io.circe::circe-generic::0.11.1",
+    ivy"io.circe::circe-parser::0.11.1",
+    ivy"com.typesafe.play::play-json::2.7.2",
+    ivy"io.argonaut::argonaut:6.2.3",
+    ivy"org.json4s::json4s-ast:3.6.5",
+    ivy"com.lihaoyi::sourcecode::0.1.5",
     ivy"com.avsystem.commons::commons-core::1.26.3",
   )
 }
@@ -310,7 +310,7 @@ object bench extends Module {
     def platformSegment = "jvm"
     def moduleDeps = Seq(upickle.jvm("2.12.7").test)
     def ivyDeps = super.ivyDeps() ++ Agg(
-      ivy"com.fasterxml.jackson.module::jackson-module-scala:2.9.4",
+      ivy"com.fasterxml.jackson.module::jackson-module-scala:2.9.8",
       ivy"com.fasterxml.jackson.core:jackson-databind:2.9.4",
     )
   }

--- a/build.sc
+++ b/build.sc
@@ -289,7 +289,6 @@ trait BenchModule extends CommonModule{
     ivy"io.argonaut::argonaut:6.2.3",
     ivy"org.json4s::json4s-ast:3.6.5",
     ivy"com.lihaoyi::sourcecode::0.1.5",
-    ivy"com.avsystem.commons::commons-core::1.26.3",
   )
 }
 

--- a/build.sc
+++ b/build.sc
@@ -49,7 +49,7 @@ trait CommonJsModule extends CommonPublishModule with ScalaJSModule{
 }
 
 object core extends Module {
-  object js extends Cross[CoreJsModule]("2.11.12", "2.12.7")
+  object js extends Cross[CoreJsModule]("2.11.12", "2.12.7", "2.13.0-M5")
 
   class CoreJsModule(val crossScalaVersion: String) extends CommonJsModule {
     def artifactName = "upickle-core"
@@ -60,7 +60,7 @@ object core extends Module {
     object test extends Tests
   }
 
-  object jvm extends Cross[CoreJvmModule]("2.11.12", "2.12.7")
+  object jvm extends Cross[CoreJvmModule]("2.11.12", "2.12.7", "2.13.0-M5")
   class CoreJvmModule(val crossScalaVersion: String) extends CommonJvmModule {
     def artifactName = "upickle-core"
     def ivyDeps = Agg(
@@ -116,7 +116,7 @@ object implicits extends Module {
     }
 
   }
-  object js extends Cross[JsModule]("2.11.12", "2.12.7")
+  object js extends Cross[JsModule]("2.11.12", "2.12.7", "2.13.0-M5")
 
   class JsModule(val crossScalaVersion: String) extends ImplicitsModule with CommonJsModule{
     def moduleDeps = Seq(core.js())
@@ -127,7 +127,7 @@ object implicits extends Module {
     }
   }
 
-  object jvm extends Cross[JvmModule]("2.11.12", "2.12.7")
+  object jvm extends Cross[JvmModule]("2.11.12", "2.12.7", "2.13.0-M5")
   class JvmModule(val crossScalaVersion: String) extends ImplicitsModule with CommonJvmModule{
     def moduleDeps = Seq(core.jvm())
     def artifactName = "upickle-implicits"
@@ -139,7 +139,7 @@ object implicits extends Module {
 
 object upack extends Module {
 
-  object js extends Cross[JsModule]("2.11.12", "2.12.7")
+  object js extends Cross[JsModule]("2.11.12", "2.12.7", "2.13.0-M5")
 
   class JsModule(val crossScalaVersion: String) extends CommonJsModule {
     def moduleDeps = Seq(core.js())
@@ -150,7 +150,7 @@ object upack extends Module {
     }
   }
 
-  object jvm extends Cross[JvmModule]("2.11.12", "2.12.7")
+  object jvm extends Cross[JvmModule]("2.11.12", "2.12.7", "2.13.0-M5")
   class JvmModule(val crossScalaVersion: String) extends CommonJvmModule {
     def moduleDeps = Seq(core.jvm())
     def artifactName = "upack"
@@ -173,27 +173,27 @@ object ujson extends Module{
     }
   }
 
-  object js extends Cross[JsModule]("2.11.12", "2.12.7")
+  object js extends Cross[JsModule]("2.11.12", "2.12.7", "2.13.0-M5")
   class JsModule(val crossScalaVersion: String) extends JsonModule with CommonJsModule{
     def moduleDeps = Seq(core.js())
 
     object test extends Tests with JawnTestModule
   }
 
-  object jvm extends Cross[JvmModule]("2.11.12", "2.12.7")
+  object jvm extends Cross[JvmModule]("2.11.12", "2.12.7", "2.13.0-M5")
   class JvmModule(val crossScalaVersion: String) extends JsonModule with CommonJvmModule{
     def moduleDeps = Seq(core.jvm())
     object test extends Tests with JawnTestModule
   }
 
-  object argonaut extends Cross[ArgonautModule]("2.11.12", "2.12.7")
+  object argonaut extends Cross[ArgonautModule]("2.11.12", "2.12.7", "2.13.0-M5")
   class ArgonautModule(val crossScalaVersion: String) extends CommonPublishModule{
     def artifactName = "ujson-argonaut"
     def platformSegment = "jvm"
     def moduleDeps = Seq(ujson.jvm())
     def ivyDeps = Agg(ivy"io.argonaut::argonaut:6.2.3")
   }
-  object json4s extends Cross[Json4sModule]("2.11.12", "2.12.7")
+  object json4s extends Cross[Json4sModule]("2.11.12", "2.12.7", "2.13.0-M5")
   class Json4sModule(val crossScalaVersion: String) extends CommonPublishModule{
     def artifactName = "ujson-json4s"
     def platformSegment = "jvm"
@@ -204,7 +204,7 @@ object ujson extends Module{
     )
   }
 
-  object circe extends Cross[CirceModule]("2.11.12", "2.12.7")
+  object circe extends Cross[CirceModule]("2.11.12", "2.12.7", "2.13.0-M5")
   class CirceModule(val crossScalaVersion: String) extends CommonPublishModule{
     def artifactName = "ujson-circe"
     def platformSegment = "jvm"
@@ -212,7 +212,7 @@ object ujson extends Module{
     def ivyDeps = Agg(ivy"io.circe::circe-parser:0.11.1")
   }
 
-  object play extends Cross[PlayModule]("2.11.12", "2.12.7")
+  object play extends Cross[PlayModule]("2.11.12", "2.12.7", "2.13.0-M5")
   class PlayModule(val crossScalaVersion: String) extends CommonPublishModule{
     def artifactName = "ujson-play"
     def platformSegment = "jvm"
@@ -244,7 +244,7 @@ trait UpickleModule extends CommonPublishModule{
 
 
 object upickle extends Module{
-  object jvm extends Cross[JvmModule]("2.11.12", "2.12.7")
+  object jvm extends Cross[JvmModule]("2.11.12", "2.12.7", "2.13.0-M5")
   class JvmModule(val crossScalaVersion: String) extends UpickleModule with CommonJvmModule{
     def moduleDeps = Seq(ujson.jvm(), upack.jvm(), implicits.jvm())
 
@@ -261,7 +261,7 @@ object upickle extends Module{
     }
   }
 
-  object js extends Cross[JsModule]("2.11.12", "2.12.7")
+  object js extends Cross[JsModule]("2.11.12", "2.12.7", "2.13.0-M5")
   class JsModule(val crossScalaVersion: String) extends UpickleModule with CommonJsModule {
     def moduleDeps = Seq(ujson.js(), upack.js(), implicits.js())
 

--- a/build.sc
+++ b/build.sc
@@ -53,6 +53,9 @@ object core extends Module {
 
   class CoreJsModule(val crossScalaVersion: String) extends CommonJsModule {
     def artifactName = "upickle-core"
+    def ivyDeps = Agg(
+      ivy"org.scala-lang.modules::scala-collection-compat::0.3.0"
+    )
 
     object test extends Tests
   }
@@ -60,6 +63,9 @@ object core extends Module {
   object jvm extends Cross[CoreJvmModule]("2.11.12", "2.12.7")
   class CoreJvmModule(val crossScalaVersion: String) extends CommonJvmModule {
     def artifactName = "upickle-core"
+    def ivyDeps = Agg(
+      ivy"org.scala-lang.modules::scala-collection-compat:0.3.0"
+    )
 
     object test extends Tests
   }

--- a/implicits/src/upickle/implicits/Readers.scala
+++ b/implicits/src/upickle/implicits/Readers.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit
 
 import upickle.core._
 
-import scala.collection.generic.CanBuildFrom
+import scala.collection.compat._
 import scala.collection.mutable
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.reflect.ClassTag
@@ -199,10 +199,10 @@ trait Readers extends upickle.core.Types with Generated with MacroImplicits{
       }
     }
   implicit def SeqLikeReader[C[_], T](implicit r: Reader[T],
-                                      cbf: CanBuildFrom[Nothing, T, C[T]]): Reader[C[T]] = new SimpleReader[C[T]] {
+                                      factory: Factory[T, C[T]]): Reader[C[T]] = new SimpleReader[C[T]] {
     override def expectedMsg = "expected sequence"
     override def visitArray(length: Int, index: Int) = new ArrVisitor[Any, C[T]] {
-      val b = cbf.apply()
+      val b = factory.newBuilder
 
       def visitValue(v: Any, index: Int): Unit = {
         b += v.asInstanceOf[T]

--- a/ujson/circe/src/ujson/circe/CirceJson.scala
+++ b/ujson/circe/src/ujson/circe/CirceJson.scala
@@ -17,7 +17,7 @@ object CirceJson extends ujson.AstTransformer[Json]{
 
   def visitArray(length: Int, index: Int) = new AstArrVisitor[Vector](x => Json.arr(x:_*))
 
-  def visitObject(length: Int, index: Int) = new AstObjVisitor[ArrayBuffer[(String, Json)]](vs => Json.obj(vs:_*))
+  def visitObject(length: Int, index: Int) = new AstObjVisitor[ArrayBuffer[(String, Json)]](vs => Json.obj(vs.toSeq:_*))
 
   def visitNull(index: Int) = Json.Null
 

--- a/ujson/src/ujson/AsyncParser.scala
+++ b/ujson/src/ujson/AsyncParser.scala
@@ -228,16 +228,16 @@ final class AsyncParser[J] protected[ujson](
           results.append(value)
         }
       }
-      Right(results)
+      Right(results.toSeq)
     } catch {
       case e: AsyncException =>
         if (done) {
           // if we are done, make sure we ended at a good stopping point
-          if (state == ASYNC_PREVAL || state == ASYNC_END) Right(results)
+          if (state == ASYNC_PREVAL || state == ASYNC_END) Right(results.toSeq)
           else Left(IncompleteParseException("exhausted input", e))
         } else {
           // we ran out of data, so return what we have so far
-          Right(results)
+          Right(results.toSeq)
         }
 
       case e: ParseException =>

--- a/ujson/src/ujson/IndexedValue.scala
+++ b/ujson/src/ujson/IndexedValue.scala
@@ -64,7 +64,7 @@ object IndexedValue extends Transformer[IndexedValue]{
       def visitValue(v: IndexedValue, index: Int): Unit = {
         out.append(v)
       }
-      def visitEnd(index: Int): IndexedValue.Arr = IndexedValue.Arr(i, out:_*)
+      def visitEnd(index: Int): IndexedValue.Arr = IndexedValue.Arr(i, out.toSeq:_*)
     }
 
     def visitObject(length: Int, i: Int) = new ObjVisitor[IndexedValue, IndexedValue.Obj] {
@@ -76,7 +76,7 @@ object IndexedValue extends Transformer[IndexedValue]{
       def visitValue(v: IndexedValue, index: Int): Unit = {
         out.append((currentKey, v))
       }
-      def visitEnd(index: Int): IndexedValue.Obj = IndexedValue.Obj(i, out:_*)
+      def visitEnd(index: Int): IndexedValue.Obj = IndexedValue.Obj(i, out.toSeq:_*)
     }
 
     def visitNull(i: Int) = IndexedValue.Null(i)

--- a/ujson/src/ujson/Value.scala
+++ b/ujson/src/ujson/Value.scala
@@ -5,6 +5,7 @@ package ujson
 import upickle.core.Util
 import upickle.core.{ObjArrVisitor, Visitor}
 
+import scala.collection.compat._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
@@ -211,9 +212,9 @@ case class Arr(value: ArrayBuffer[Value]) extends Value
 
 object Arr{
   implicit def from[T <% Value](items: TraversableOnce[T]): Arr =
-    Arr(items.map(x => x: Value).to[mutable.ArrayBuffer])
+    Arr(items.map(x => x: Value).to(mutable.ArrayBuffer))
 
-  def apply(items: Value*): Arr = Arr(items.to[mutable.ArrayBuffer])
+  def apply(items: Value*): Arr = Arr(items.to(mutable.ArrayBuffer))
 }
 case class Num(value: Double) extends Value
 sealed abstract class Bool extends Value{

--- a/upack/src/upack/Msg.scala
+++ b/upack/src/upack/Msg.scala
@@ -2,6 +2,7 @@ package upack
 
 import upickle.core.{ArrVisitor, ObjVisitor, Visitor}
 
+import scala.collection.compat._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
@@ -106,7 +107,7 @@ case class Str(value: String) extends Msg
 case class Binary(value: Array[Byte]) extends Msg
 case class Arr(value: mutable.ArrayBuffer[Msg]) extends Msg
 object Arr{
-  def apply(items: Msg*): Arr = Arr(items.to[mutable.ArrayBuffer])
+  def apply(items: Msg*): Arr = Arr(items.to(mutable.ArrayBuffer))
 }
 case class Obj(value: mutable.LinkedHashMap[Msg, Msg]) extends Msg
 object Obj{

--- a/upickle/test/src/upickle/StructTests.scala
+++ b/upickle/test/src/upickle/StructTests.scala
@@ -61,7 +61,6 @@ object StructTests extends TestSuite {
         'Seq - rw(collection.mutable.Seq("omg", "i am", "cow"), """["omg","i am","cow"]""")
         'Buffer - rw(collection.mutable.Buffer("omg", "i am", "cow"), """["omg","i am","cow"]""")
         'SortedSet - rw(collection.mutable.SortedSet("omg", "i am", "cow"), """["cow","i am","omg"]""")
-        'LinkedList - rw(collection.mutable.LinkedList("omg", "i am", "cow"), """["omg","i am","cow"]""")
       }
       'Map {
         'Structured-rw(

--- a/upickle/test/src/upickle/StructTests.scala
+++ b/upickle/test/src/upickle/StructTests.scala
@@ -135,9 +135,9 @@ object StructTests extends TestSuite {
 
     'transmutation{
       'vectorToList{
-        val vectorToList = read[Seq[Double]](write(Vector(1.1, 2.2, 3.3)))
+        val vectorToList = read[List[Double]](write(Vector(1.1, 2.2, 3.3)))
         assert(
-          vectorToList.isInstanceOf[Vector[Double]],
+          vectorToList.isInstanceOf[List[Double]],
           vectorToList == List(1.1, 2.2, 3.3)
         )
 

--- a/upickle/test/src/upickle/StructTests.scala
+++ b/upickle/test/src/upickle/StructTests.scala
@@ -2,6 +2,7 @@ package upickle
 import utest._
 import upickle.legacy.{read, write}
 
+import scala.collection.compat._
 import scala.concurrent.duration._
 import TestUtil._
 import java.util.UUID
@@ -12,7 +13,7 @@ import scala.reflect.ClassTag
 import language.postfixOps
 
 object StructTests extends TestSuite {
-  Seq(1).to[Vector]
+  Seq(1).to(Vector)
   val tests = Tests {
     'arrays{
       'empty-rwk(Array[Int](), "[]")(_.toSeq)


### PR DESCRIPTION
This PR makes a bunch of changes, allowing to cross-compile upickle in 2.13.

~I'll push the extra commit enabling actual cross-compilation if the CI is fine with the current changes.~ (done)