### PR TITLE
Switch to scala 2.13.0-RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: scala
 
 before_install:
-  - curl -L -o ~/bin/mill https://github.com/lihaoyi/mill/releases/download/0.3.4/0.3.4 && chmod +x ~/bin/mill
+  - curl -L -o ~/bin/mill https://github.com/lihaoyi/mill/releases/download/0.3.6/0.3.6-85-38fce6 && chmod +x ~/bin/mill
 
 script:
 - mill __[$TRAVIS_SCALA_VERSION].test
@@ -11,5 +11,4 @@ jobs:
   include:
     - scala: 2.11.12
     - scala: 2.12.7
-    - scala: 2.13.0-M5
-      script: for proj in core ujson upack upickle; do for pf in jvm js; do mill $proj.$pf[$TRAVIS_SCALA_VERSION].test || exit 1; done || exit 1; done
+    - scala: 2.13.0-RC1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ script:
 jobs:
   include:
     - scala: 2.11.12
-    - scala: 2.12.7
+    - scala: 2.12.8
     - scala: 2.13.0-RC1

--- a/build.sc
+++ b/build.sc
@@ -29,7 +29,7 @@ trait CommonModule extends ScalaModule {
   def zincWorker: ZincWorkerModule =
     CustomZincWorker
 
-  def scalacOptions = T{ if (scalaVersion() == "2.12.7") Seq("-opt:l:method") else Nil }
+  def scalacOptions = T{ if (scalaVersion() == "2.12.8") Seq("-opt:l:method") else Nil }
   def platformSegment: String
 
   def sources = T.sources(
@@ -77,7 +77,7 @@ trait CommonJsModule extends CommonPublishModule with ScalaJSModule{
 }
 
 object core extends Module {
-  object js extends Cross[CoreJsModule]("2.11.12", "2.12.7", "2.13.0-RC1")
+  object js extends Cross[CoreJsModule]("2.11.12", "2.12.8", "2.13.0-RC1")
 
   class CoreJsModule(val crossScalaVersion: String) extends CommonJsModule {
     def artifactName = "upickle-core"
@@ -88,7 +88,7 @@ object core extends Module {
     object test extends Tests
   }
 
-  object jvm extends Cross[CoreJvmModule]("2.11.12", "2.12.7", "2.13.0-RC1")
+  object jvm extends Cross[CoreJvmModule]("2.11.12", "2.12.8", "2.13.0-RC1")
   class CoreJvmModule(val crossScalaVersion: String) extends CommonJvmModule {
     def artifactName = "upickle-core"
     def ivyDeps = Agg(
@@ -144,7 +144,7 @@ object implicits extends Module {
     }
 
   }
-  object js extends Cross[JsModule]("2.11.12", "2.12.7", "2.13.0-RC1")
+  object js extends Cross[JsModule]("2.11.12", "2.12.8", "2.13.0-RC1")
 
   class JsModule(val crossScalaVersion: String) extends ImplicitsModule with CommonJsModule{
     def moduleDeps = Seq(core.js())
@@ -155,7 +155,7 @@ object implicits extends Module {
     }
   }
 
-  object jvm extends Cross[JvmModule]("2.11.12", "2.12.7", "2.13.0-RC1")
+  object jvm extends Cross[JvmModule]("2.11.12", "2.12.8", "2.13.0-RC1")
   class JvmModule(val crossScalaVersion: String) extends ImplicitsModule with CommonJvmModule{
     def moduleDeps = Seq(core.jvm())
     def artifactName = "upickle-implicits"
@@ -167,7 +167,7 @@ object implicits extends Module {
 
 object upack extends Module {
 
-  object js extends Cross[JsModule]("2.11.12", "2.12.7", "2.13.0-RC1")
+  object js extends Cross[JsModule]("2.11.12", "2.12.8", "2.13.0-RC1")
 
   class JsModule(val crossScalaVersion: String) extends CommonJsModule {
     def moduleDeps = Seq(core.js())
@@ -178,7 +178,7 @@ object upack extends Module {
     }
   }
 
-  object jvm extends Cross[JvmModule]("2.11.12", "2.12.7", "2.13.0-RC1")
+  object jvm extends Cross[JvmModule]("2.11.12", "2.12.8", "2.13.0-RC1")
   class JvmModule(val crossScalaVersion: String) extends CommonJvmModule {
     def moduleDeps = Seq(core.jvm())
     def artifactName = "upack"
@@ -201,27 +201,27 @@ object ujson extends Module{
     }
   }
 
-  object js extends Cross[JsModule]("2.11.12", "2.12.7", "2.13.0-RC1")
+  object js extends Cross[JsModule]("2.11.12", "2.12.8", "2.13.0-RC1")
   class JsModule(val crossScalaVersion: String) extends JsonModule with CommonJsModule{
     def moduleDeps = Seq(core.js())
 
     object test extends Tests with JawnTestModule
   }
 
-  object jvm extends Cross[JvmModule]("2.11.12", "2.12.7", "2.13.0-RC1")
+  object jvm extends Cross[JvmModule]("2.11.12", "2.12.8", "2.13.0-RC1")
   class JvmModule(val crossScalaVersion: String) extends JsonModule with CommonJvmModule{
     def moduleDeps = Seq(core.jvm())
     object test extends Tests with JawnTestModule
   }
 
-  object argonaut extends Cross[ArgonautModule]("2.11.12", "2.12.7", "2.13.0-RC1")
+  object argonaut extends Cross[ArgonautModule]("2.11.12", "2.12.8", "2.13.0-RC1")
   class ArgonautModule(val crossScalaVersion: String) extends CommonPublishModule{
     def artifactName = "ujson-argonaut"
     def platformSegment = "jvm"
     def moduleDeps = Seq(ujson.jvm())
     def ivyDeps = Agg(ivy"io.argonaut::argonaut:6.2.3")
   }
-  object json4s extends Cross[Json4sModule]("2.11.12", "2.12.7", "2.13.0-RC1")
+  object json4s extends Cross[Json4sModule]("2.11.12", "2.12.8", "2.13.0-RC1")
   class Json4sModule(val crossScalaVersion: String) extends CommonPublishModule{
     def artifactName = "ujson-json4s"
     def platformSegment = "jvm"
@@ -232,7 +232,7 @@ object ujson extends Module{
     )
   }
 
-  object circe extends Cross[CirceModule]("2.11.12", "2.12.7", "2.13.0-RC1")
+  object circe extends Cross[CirceModule]("2.11.12", "2.12.8", "2.13.0-RC1")
   class CirceModule(val crossScalaVersion: String) extends CommonPublishModule{
     def artifactName = "ujson-circe"
     def platformSegment = "jvm"
@@ -240,7 +240,7 @@ object ujson extends Module{
     def ivyDeps = Agg(ivy"io.circe::circe-parser:0.12.0-M1")
   }
 
-  object play extends Cross[PlayModule]("2.11.12", "2.12.7", "2.13.0-RC1")
+  object play extends Cross[PlayModule]("2.11.12", "2.12.8", "2.13.0-RC1")
   class PlayModule(val crossScalaVersion: String) extends CommonPublishModule{
     def artifactName = "ujson-play"
     def platformSegment = "jvm"
@@ -272,7 +272,7 @@ trait UpickleModule extends CommonPublishModule{
 
 
 object upickle extends Module{
-  object jvm extends Cross[JvmModule]("2.11.12", "2.12.7", "2.13.0-RC1")
+  object jvm extends Cross[JvmModule]("2.11.12", "2.12.8", "2.13.0-RC1")
   class JvmModule(val crossScalaVersion: String) extends UpickleModule with CommonJvmModule{
     def moduleDeps = Seq(ujson.jvm(), upack.jvm(), implicits.jvm())
 
@@ -289,7 +289,7 @@ object upickle extends Module{
     }
   }
 
-  object js extends Cross[JsModule]("2.11.12", "2.12.7", "2.13.0-RC1")
+  object js extends Cross[JsModule]("2.11.12", "2.12.8", "2.13.0-RC1")
   class JsModule(val crossScalaVersion: String) extends UpickleModule with CommonJsModule {
     def moduleDeps = Seq(ujson.js(), upack.js(), implicits.js())
 
@@ -311,7 +311,7 @@ object upickle extends Module{
 }
 
 trait BenchModule extends CommonModule{
-  def scalaVersion = "2.12.7"
+  def scalaVersion = "2.12.8"
   def millSourcePath = build.millSourcePath / "bench"
   def ivyDeps = Agg(
     ivy"io.circe::circe-core::0.12.0-M1",
@@ -328,7 +328,7 @@ object bench extends Module {
   object js extends BenchModule with ScalaJSModule {
     def scalaJSVersion = "0.6.27"
     def platformSegment = "js"
-    def moduleDeps = Seq(upickle.js("2.12.7").test)
+    def moduleDeps = Seq(upickle.js("2.12.8").test)
     def run(args: String*) = T.command {
       finalMainClassOpt() match{
         case Left(err) => mill.eval.Result.Failure(err)
@@ -345,7 +345,7 @@ object bench extends Module {
 
   object jvm extends BenchModule {
     def platformSegment = "jvm"
-    def moduleDeps = Seq(upickle.jvm("2.12.7").test)
+    def moduleDeps = Seq(upickle.jvm("2.12.8").test)
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"com.fasterxml.jackson.module::jackson-module-scala:2.9.8",
       ivy"com.fasterxml.jackson.core:jackson-databind:2.9.4",


### PR DESCRIPTION
~Blocked by https://github.com/FasterXML/jackson-module-scala/pull/407.~

Maybe we should wait for proper `2.13.0-RC1` support in mill too.