### PR TITLE
Fix indentation in Api.scala snippet

### DIFF
--- a/upickleReadme/Readme.scalatex
+++ b/upickleReadme/Readme.scalatex
@@ -302,7 +302,7 @@
         The following common operations are available on any uPickle module,
         e.g. @code{upickle.default} or @code{upickle.legacy}:
 
-      @hl.ref(wd/'upickle/'src/'upickle/"Api.scala", Seq("trait Api", ""), "// End Api")
+      @hl.ref(wd/'upickle/'src/'upickle/"Api.scala", Seq("trait Api"), "// End Api")
 
   @sect{Customization}
     @sect{Custom Picklers}


### PR DESCRIPTION
The Common Operations section (http://www.lihaoyi.com/upickle/#CommonOperations) has a snippet of `Api.scala`, this snippet misses the first 4 characters of each line, which results in weird highlighting. 

By dropping the `""` in the Seq, the complete file gets rendered correctly.