### PR TITLE
Customizable tagName per sealed type.

### DIFF
--- a/core/src/upickle/core/Types.scala
+++ b/core/src/upickle/core/Types.scala
@@ -43,6 +43,7 @@ trait Types{ types =>
 
       case (r1: TaggedReader[T], w1: TaggedWriter[T]) =>
         new TaggedReadWriter[T] {
+          override val tagName: String = findTagName(Seq(r1, w1))
           def findReader(s: String) = r1.findReader(s)
           def findWriter(v: Any) = w1.findWriter(v)
         }
@@ -128,6 +129,15 @@ trait Types{ types =>
     def merge[T](writers: Writer[_ <: T]*) = {
       new TaggedWriter.Node(writers.asInstanceOf[Seq[TaggedWriter[T]]]:_*)
     }
+  }
+
+  private def findTagName(ts: Seq[Tagged]): String = {
+    val tagName = ts.head.tagName
+    for (t <- ts.iterator.drop(1)) {
+      // Enforce consistent tag names.
+      if (t.tagName != tagName) throw new IllegalArgumentException(s"Inconsistent tag names: [$tagName, ${t.tagName}]")
+    }
+    tagName
   }
 
   class TupleNWriter[V](val writers: Array[Writer[_]], val f: V => Array[Any]) extends Writer[V]{
@@ -232,7 +242,7 @@ trait Types{ types =>
   def taggedExpectedMsg: String
   def taggedArrayContext[T](taggedReader: TaggedReader[T], index: Int): ArrVisitor[Any, T] = throw new Abort(taggedExpectedMsg)
   def taggedObjectContext[T](taggedReader: TaggedReader[T], index: Int): ObjVisitor[Any, T] = throw new Abort(taggedExpectedMsg)
-  def taggedWrite[T, R](w: CaseW[T], tag: String, out: Visitor[_, R], v: T): R
+  def taggedWrite[T, R](w: CaseW[T], tagName: String, tag: String, out: Visitor[_, R], v: T): R
 
   private[this] def scanChildren[T, V](xs: Seq[T])(f: T => V) = {
     var x: V = null.asInstanceOf[V]
@@ -243,7 +253,18 @@ trait Types{ types =>
     }
     x
   }
-  trait TaggedReader[T] extends SimpleReader[T]{
+  trait Tagged {
+
+    /**
+      * Name of the object key used to identify the subclass tag.
+      * Readers will fast path if this is the first field of the object.
+      * Otherwise, Readers will have to buffer the content and find the tag later.
+      * While naming, consider that some implementations (e.g. vpack) may sort object keys,
+      * so symbol prefixes work well for ensuring the tag is the first property.
+      */
+    def tagName: String
+  }
+  trait TaggedReader[T] extends SimpleReader[T] with Tagged {
     def findReader(s: String): Reader[T]
 
     override def expectedMsg = taggedExpectedMsg
@@ -251,30 +272,32 @@ trait Types{ types =>
     override def visitObject(length: Int, index: Int) = taggedObjectContext(this, index)
   }
   object TaggedReader{
-    class Leaf[T](tag: String, r: Reader[T]) extends TaggedReader[T]{
+    class Leaf[T](override val tagName: String, tag: String, r: Reader[T]) extends TaggedReader[T]{
       def findReader(s: String) = if (s == tag) r else null
     }
     class Node[T](rs: TaggedReader[_ <: T]*) extends TaggedReader[T]{
+      override val tagName: String = findTagName(rs)
       def findReader(s: String) = scanChildren(rs)(_.findReader(s)).asInstanceOf[Reader[T]]
     }
   }
 
-  trait TaggedWriter[T] extends Writer[T]{
+  trait TaggedWriter[T] extends Writer[T] with Tagged {
     def findWriter(v: Any): (String, CaseW[T])
     def write0[R](out: Visitor[_, R], v: T): R = {
       val (tag, w) = findWriter(v)
-      taggedWrite(w, tag, out, v)
+      taggedWrite(w, tagName, tag, out, v)
 
     }
   }
   object TaggedWriter{
-    class Leaf[T](c: ClassTag[_], tag: String, r: CaseW[T]) extends TaggedWriter[T]{
+    class Leaf[T](c: ClassTag[_], override val tagName: String, tag: String, r: CaseW[T]) extends TaggedWriter[T]{
       def findWriter(v: Any) = {
         if (c.runtimeClass.isInstance(v)) tag -> r
         else null
       }
     }
     class Node[T](rs: TaggedWriter[_ <: T]*) extends TaggedWriter[T]{
+      override val tagName: String = findTagName(rs)
       def findWriter(v: Any) = scanChildren(rs)(_.findWriter(v)).asInstanceOf[(String, CaseW[T])]
     }
   }
@@ -285,7 +308,7 @@ trait Types{ types =>
 
   }
   object TaggedReadWriter{
-    class Leaf[T](c: ClassTag[_], tag: String, r: CaseW[T] with Reader[T]) extends TaggedReadWriter[T]{
+    class Leaf[T](c: ClassTag[_], override val tagName: String, tag: String, r: CaseW[T] with Reader[T]) extends TaggedReadWriter[T]{
       def findReader(s: String) = if (s == tag) r else null
       def findWriter(v: Any) = {
         if (c.runtimeClass.isInstance(v)) (tag -> r)
@@ -293,6 +316,7 @@ trait Types{ types =>
       }
     }
     class Node[T](rs: TaggedReadWriter[_ <: T]*) extends TaggedReadWriter[T]{
+      override val tagName: String = findTagName(rs)
       def findReader(s: String) = scanChildren(rs)(_.findReader(s)).asInstanceOf[Reader[T]]
       def findWriter(v: Any) = scanChildren(rs)(_.findWriter(v)).asInstanceOf[(String, CaseW[T])]
     }

--- a/implicits/src/upickle/implicits/discriminator.scala
+++ b/implicits/src/upickle/implicits/discriminator.scala
@@ -1,0 +1,19 @@
+package upickle.implicits
+
+import scala.annotation.StaticAnnotation
+
+/**
+  * Defines the name of a new field (not defined in the class itself)
+  * to serve as the discriminator property name for identifying subclasses.
+  *
+  * For naming, consider that some implementations (e.g. vpack) may sort object keys,
+  * so symbol prefixes work well for ensuring the tag is the first property.
+  * Readers will fast path if this is the first field of the object.
+  * Otherwise, Readers will have to buffer the content and find the tag later.
+  *
+  * You can also tag the subclasses with [[key]] to override values for this field,
+  * which will otherwise default to the FQCN of the classname.
+  *
+  * @see https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/
+  */
+case class discriminator(propertyName: String = "$type") extends StaticAnnotation

--- a/implicits/src/upickle/implicits/internal/Macros.scala
+++ b/implicits/src/upickle/implicits/internal/Macros.scala
@@ -211,7 +211,11 @@ object Macros {
       sealedParent.fold(derived) { parent =>
         val tagName = customDiscriminator(parent) match {
           case Some(customName) => Literal(Constant(customName))
-          case None => q"${c.prefix}.tagName"
+          case None =>
+            c.prefix.actualType.members.find(_.name == TermName("tagName")) match {
+              case None => Literal(Constant("$type")) // legacyApi doesn't use this.
+              case Some(_) => q"${c.prefix}.tagName"
+            }
         }
         val tag = customKey(tpe.typeSymbol).getOrElse(tpe.typeSymbol.fullName)
         q"""${c.prefix}.annotate($derived, $tagName, $tag)"""

--- a/implicits/src/upickle/implicits/key.scala
+++ b/implicits/src/upickle/implicits/key.scala
@@ -2,4 +2,11 @@ package upickle.implicits
 
 import scala.annotation.StaticAnnotation
 
+/**
+  * May be used on either:
+  * 1. subclasses to override [[discriminator]] values (default: FQCN)
+  * 2. class fields to override field name.
+  *
+  * @see http://www.lihaoyi.com/upickle/#CustomKeys
+  */
 case class key(s: String) extends StaticAnnotation

--- a/upickle/src/upickle/Api.scala
+++ b/upickle/src/upickle/Api.scala
@@ -163,7 +163,7 @@ trait LegacyApi extends Api{
     }
 
   }
-  def taggedWrite[T, R](w: CaseW[T], tag: String, out: Visitor[_,  R], v: T): R = {
+  def taggedWrite[T, R](w: CaseW[T], tagName: String, tag: String, out: Visitor[_,  R], v: T): R = {
     val ctx = out.asInstanceOf[Visitor[Any, R]].visitArray(2, -1)
     ctx.visitValue(out.visitString(objectTypeKeyWriteMap(tag), -1), -1)
 

--- a/upickle/test/src/upickle/example/ExampleTests.scala
+++ b/upickle/test/src/upickle/example/ExampleTests.scala
@@ -56,6 +56,7 @@ object Keyed{
   }
 }
 object KeyedTag{
+  @discriminator("customDiscriminator")
   sealed trait A
   object A{
     implicit val rw: RW[A] = RW.merge(B.rw, macroRW[C.type])
@@ -272,8 +273,8 @@ object ExampleTests extends TestSuite {
         read[KeyBar]("""{"hehehe": 10}""")    ==> KeyBar(10)
       }
       test("tag"){
-        write(B(10))                          ==> """{"$type":"Bee","i":10}"""
-        read[B]("""{"$type":"Bee","i":10}""") ==> B(10)
+        write(B(10))                          ==> """{"customDiscriminator":"Bee","i":10}"""
+        read[B]("""{"customDiscriminator":"Bee","i":10}""") ==> B(10)
       }
       test("snakeCase"){
         object SnakePickle extends upickle.AttributeTagged{

--- a/upickle/test/src/upickle/example/ExampleTests.scala
+++ b/upickle/test/src/upickle/example/ExampleTests.scala
@@ -56,7 +56,7 @@ object Keyed{
   }
 }
 object KeyedTag{
-  @discriminator("customDiscriminator")
+  @upickle.implicits.discriminator("customDiscriminator")
   sealed trait A
   object A{
     implicit val rw: RW[A] = RW.merge(B.rw, macroRW[C.type])


### PR DESCRIPTION
Port of https://github.com/rallyhealth/weePickle/pull/13.

## Summary
Allows different class hierarchies within a single document to use different discriminators, e.g. `providerType` and `locationType` below. Adds support for [OpenAPI 3 Inheritance and Polymorphism](https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/) custom `discriminator/propertyName` keys.

```json
{
  "providerType": "place",
  "locations": [
    {
      "locationType": "lab",
      "labStuff": "..."
    },
    {
      "locationType": "hospital",
      "hospitalStuff": "..."
    }
  ]
}
```

## Problem
uPickle allows overriding the default `$type` discriminator key, but only at the "bundle" level.

## Solution
I've replaced that global override with a per-model annotation.

```scala
@discriminator("locationType")
sealed trait ProviderLocation
case class Hospital() extends ProviderLocation
case class Lab() extends ProviderLocation

sealed trait Provider
@discriminator("providerType")
case class Place(locations: Seq[ProviderLocation]) extends Provider
```

## Notes
* This will break binary compatibility with previous releases.
* I didn't port over the docs from [differences.md](https://github.com/rallyhealth/weePickle/pull/13/files#diff-cc7f68184b847bce84988df9a69d44e8). Leaving it up to you how you'd like to doc this on the site. You're a better writer than I am. :)
