### PR TITLE
Perf: Avoid unnecessary buffer reallocation

### DIFF
--- a/core/src/upickle/core/BufferingInputStreamParser.scala
+++ b/core/src/upickle/core/BufferingInputStreamParser.scala
@@ -69,7 +69,7 @@ trait BufferingInputStreamParser{
       val growGoalSize = (until - dropped + 1)
       while (newSize <= growGoalSize) newSize *= 2
 
-      val arr = if (newSize > buffer.length / 2) new Array[Byte](newSize) else buffer
+      val arr = if (newSize > buffer.length) new Array[Byte](newSize) else buffer
 
       System.arraycopy(buffer, dropped - firstIdx, arr, 0, lastIdx - dropped)
       firstIdx = dropped

--- a/core/src/upickle/core/BufferingInputStreamParser.scala
+++ b/core/src/upickle/core/BufferingInputStreamParser.scala
@@ -63,7 +63,7 @@ trait BufferingInputStreamParser{
     //
     // - https://github.com/scala-js/scala-js/issues/3913
     val untilBufferOffset = until - firstIdx + 1
-    if (untilBufferOffset >= buffer.size){
+    if (untilBufferOffset >= buffer.length){
       var newSize = buffer.length
 
       val growGoalSize = (until - dropped + 1)


### PR DESCRIPTION
Port of https://github.com/rallyhealth/weePickle/pull/36.

There's far more `Array[Byte]` allocation happening in `BufferingInputStreamParser` than there should be. 1.56 GB total / 25,508 objects = 64 KB avg size.

![Screen Shot 2020-01-08 at 5 16 41 PM](https://user-images.githubusercontent.com/663139/72021169-69efbd80-323b-11ea-9f08-582494ea0184.png)

Debugger reveals that when `buffer.length` is 65,536, and `newSize` is 65,536, implementation reallocates `buffer` every time just to left shift the contents. Avoidable.

![BufferingInputStreamParser requestUntil](https://user-images.githubusercontent.com/663139/72021066-24cb8b80-323b-11ea-8c02-63148c297a2d.png)
