### PR TITLE
Correctness over mutable java.lang.CharSequence inputs.

### DIFF
--- a/core/src/upickle/core/StringVisitor.scala
+++ b/core/src/upickle/core/StringVisitor.scala
@@ -2,5 +2,5 @@ package upickle.core
 
 object StringVisitor extends SimpleVisitor[Nothing, Any] {
   def expectedMsg = "expected string"
-  override def visitString(s: CharSequence, index: Int) = s
+  override def visitString(s: CharSequence, index: Int): String = s.toString
 }

--- a/ujson/src/ujson/IndexedValue.scala
+++ b/ujson/src/ujson/IndexedValue.scala
@@ -88,6 +88,6 @@ object IndexedValue extends Transformer[IndexedValue]{
     def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, i: Int) = IndexedValue.Num(i, s, decIndex, expIndex)
     override def visitFloat64(d: Double, i: Int) = IndexedValue.NumRaw(i, d)
 
-    def visitString(s: CharSequence, i: Int) = IndexedValue.Str(i, s)
+    def visitString(s: CharSequence, i: Int) = IndexedValue.Str(i, s.toString)
   }
 }

--- a/upickle/test/src/upickle/MacroTests.scala
+++ b/upickle/test/src/upickle/MacroTests.scala
@@ -141,6 +141,12 @@ object MacroTests extends TestSuite {
           // different code-path than for tag-first dicts, using an intermediate
           // AST, so make sure that code path works too.
           test - rw(C("a", "b"), """{"s1":"a","s2":"b", "$type": "upickle.Hierarchy.C"}""")
+          test("mutable") {
+            // Make sure that the buffering done by the macro captures immutable values.
+            val r = new upickle.default.Reader.Delegate(new MutableCharSequenceVisitor(upickle.default.reader[C]))
+            val w = upickle.default.writer[C]
+            rw(C("a", "b"), """{"s1":"a","s2":"b", "$type": "upickle.Hierarchy.C"}""")(r, w)
+          }
           test - rw(B(1), """{"i":1, "$type": "upickle.Hierarchy.B"}""")
           test - rw(C("a", "b"): A, """{"s1":"a","s2":"b", "$type": "upickle.Hierarchy.C"}""")
         }

--- a/upickle/test/src/upickle/MutableCharSequenceVisitor.scala
+++ b/upickle/test/src/upickle/MutableCharSequenceVisitor.scala
@@ -1,0 +1,61 @@
+package upickle
+
+import java.nio.CharBuffer
+
+import upickle.core.{ArrVisitor, ObjVisitor, Visitor}
+
+/**
+  * For testing that the delegate visitor doesn't make assumptions
+  * about the immutability of the CharSequences it receives.
+  */
+class MutableCharSequenceVisitor[T, J](v: Visitor[T, J]) extends Visitor.Delegate[T, J](v) {
+
+  private def withMutableString[R](s: CharSequence)(f: CharSequence => R): R = {
+    val buf = s.toString.toCharArray
+    val r = f(CharBuffer.wrap(buf))
+    // Clear the buffer with something recognizable.
+    for (i <- 0 until buf.length) {
+      buf(i) = 'M' // for Mutable
+    }
+    r
+  }
+
+  override def visitArray(length: Int, index: Int): ArrVisitor[T, J] = {
+    val arr = super.visitArray(length, index)
+    new ArrVisitor[T, J] {
+      override def subVisitor: Visitor[_, _] = new MutableCharSequenceVisitor(arr.subVisitor)
+
+      override def visitValue(v: T, index: Int): Unit = arr.visitValue(v, index)
+
+      override def visitEnd(index: Int): J = arr.visitEnd(index)
+    }
+  }
+
+  override def visitObject(length: Int, index: Int): ObjVisitor[T, J] = {
+    val obj = super.visitObject(length, index)
+    new ObjVisitor[T, J] {
+      override def visitKey(index: Int): Visitor[_, _] = obj.visitKey(index)
+
+      override def visitKeyValue(v: Any): Unit = obj.visitKeyValue(v)
+
+      override def subVisitor: Visitor[_, _] = new MutableCharSequenceVisitor(obj.subVisitor)
+
+      override def visitValue(v: T, index: Int): Unit = obj.visitValue(v, index)
+
+      override def visitEnd(index: Int): J = obj.visitEnd(index)
+    }
+  }
+
+  override def visitString(s: CharSequence, index: Int): J = withMutableString(s) { mut =>
+    super.visitString(mut, index)
+  }
+
+  override def visitFloat64StringParts(
+    s: CharSequence,
+    decIndex: Int,
+    expIndex: Int,
+    index: Int
+  ): J = withMutableString(s) { mut =>
+    super.visitFloat64StringParts(mut, decIndex, expIndex, index)
+  }
+}


### PR DESCRIPTION
I found a corner-case correctness issue when feeding [mutable](https://github.com/rallyhealth/weePickle/blob/b088175f380bd47e830376b909e064052c85cdfc/weejson/jackson/src/com/rallyhealth/weejson/v0/jackson/VisitorJsonGenerator.scala#L66-L71) `CharSequence`s into the generated macros.

Input of `"""{"s1":"a","s2":"b", "$type": "upickle.Hierarchy.C"}"""` fails in this scenario. Macro ends up with values of `Str("upickle.Hierarchy.C")` for "s1" and "s2".

Freezing `Str` to `CharSequence.toString` resolves the issue. We'd also need `StringVisitor` to freeze to a `String` since it's used by the macro for parsing the value of `"$type"`.

AFAIK, the ujson parsers only emit `java.lang.String` anyway, so I expect the cost should be negligible. As long as that's true, it's only an issue for extensibility outside the library.