### PR TITLE
Bugfix: EitherWriter writes outside of array.

### DIFF
--- a/implicits/src/upickle/implicits/Writers.scala
+++ b/implicits/src/upickle/implicits/Writers.scala
@@ -129,14 +129,14 @@ trait Writers extends upickle.core.Types with Generated with MacroImplicits with
     def write0[R](out: Visitor[_, R], v: Either[T1, T2]): R = v match{
       case Left(t1) =>
         val ctx = out.visitArray(2, -1).narrow
-        ctx.visitValue(out.visitFloat64StringParts("0", -1, -1, -1), -1)
+        ctx.visitValue(ctx.subVisitor.visitFloat64StringParts("0", -1, -1, -1), -1)
 
         ctx.visitValue(implicitly[Writer[T1]].write(ctx.subVisitor, t1), -1)
 
         ctx.visitEnd(-1)
       case Right(t2) =>
         val ctx = out.visitArray(2, -1).narrow
-        ctx.visitValue(out.visitFloat64StringParts("1", -1, -1, -1), -1)
+        ctx.visitValue(ctx.subVisitor.visitFloat64StringParts("1", -1, -1, -1), -1)
 
         ctx.visitValue(implicitly[Writer[T2]].write(ctx.subVisitor, t2), -1)
 

--- a/upickle/src/upickle/Api.scala
+++ b/upickle/src/upickle/Api.scala
@@ -175,9 +175,9 @@ trait LegacyApi extends Api{
   }
   def taggedWrite[T, R](w: CaseW[T], tag: String, out: Visitor[_,  R], v: T): R = {
     val ctx = out.asInstanceOf[Visitor[Any, R]].visitArray(2, -1)
-    ctx.visitValue(out.visitString(objectTypeKeyWriteMap(tag), -1), -1)
+    ctx.visitValue(ctx.subVisitor.visitString(objectTypeKeyWriteMap(tag), -1), -1)
 
-    ctx.visitValue(w.write(out, v), -1)
+    ctx.visitValue(w.write(ctx.subVisitor, v), -1)
 
     ctx.visitEnd(-1)
   }
@@ -272,7 +272,7 @@ trait AttributeTagged extends Api{
     val keyVisitor = ctx.visitKey(-1)
 
     ctx.visitKeyValue(keyVisitor.visitString(tagName, -1))
-    ctx.visitValue(out.visitString(objectTypeKeyWriteMap(tag), -1), -1)
+    ctx.visitValue(ctx.subVisitor.visitString(objectTypeKeyWriteMap(tag), -1), -1)
     w.writeToObject(ctx, v)
     val res = ctx.visitEnd(-1)
     res


### PR DESCRIPTION
I have a Visitor that prevents further writes after a single value (e.g. okay: `["1", 2]`, but not okay: `"1" [2]`). In this case, writing the "1" to the root visitor instead of the array visitor prematurely triggers a close() on the underlying resource. The encoding for `Left(2)` is `["1" , 2]` regardless, since the `ctx.visitValue()` call is correct, but the EitherWriter was sending the `.visitFloat64StringParts("1")` to the wrong place which causes problems if visiting the root prevents multiple calls.

Found during https://github.com/rallyhealth/weePickle/pull/52.