### PR TITLE
BugFix: Visitor.map/MapReader loses obj/array lengths.

### DIFF
--- a/core/src/upickle/core/Visitor.scala
+++ b/core/src/upickle/core/Visitor.scala
@@ -195,10 +195,10 @@ object Visitor{
     override def visitTrue(index: Int) = mapFunction(delegatedReader.visitTrue(index))
 
     override def visitObject(length: Int, index: Int): ObjVisitor[T, Z] = {
-      new MapObjContext[T, V, Z](delegatedReader.visitObject(-1, index), mapNonNullsFunction)
+      new MapObjContext[T, V, Z](delegatedReader.visitObject(length, index), mapNonNullsFunction)
     }
     override def visitArray(length: Int, index: Int): ArrVisitor[T, Z] = {
-      new MapArrContext[T, V, Z](delegatedReader.visitArray(-1, index), mapNonNullsFunction)
+      new MapArrContext[T, V, Z](delegatedReader.visitArray(length, index), mapNonNullsFunction)
     }
 
     override def visitFloat32(d: Float, index: Int) = mapFunction(delegatedReader.visitFloat32(d, index))

--- a/upack/test/src/upack/UnitTests.scala
+++ b/upack/test/src/upack/UnitTests.scala
@@ -11,6 +11,11 @@ object UnitTests extends TestSuite{
       val written = upack.write(msg)
       upack.read(written: geny.Readable) ==> msg
     }
+    test("map"){
+      val msg = Arr(Str("a"))
+      val written = transform(msg, new MsgPackWriter().map(_.toByteArray)) // does map preserve array lengths?
+      upack.read(written: geny.Readable) ==> msg
+    }
     test("compositeKeys"){
       val msg = Obj(Arr(Int32(1), Int32(2)) -> Int32(1))
       val written = upack.write(msg)


### PR DESCRIPTION
I *think* this is probably a bug.

MsgPack needs obj/arr lengths to be known up front, but `Visitor.map()` overrides them to -1.

I can't think of a reason that the number of elements emitted to the delegate could be modified by `Visitor.map(J => Z)`. The `mapFunction` only applies over return values, which would have no effect on the number of `MapArrContext.subvisitor/visitValue` calls.

Certainly a child of `Visitor.Delegate` that wanted to do filtering *could* mess with the calls going to delegate `ObjArrVisitors`, but that's a different class than `MapReader`, and even then, I'd expect it to be the responsibility of the *child* class mucking with the elements to set length to -1 if unknowable.