### PR TITLE
ujson.Readable.from{Path,File}: close input stream

### DIFF
--- a/ujson/src/ujson/Readable.scala
+++ b/ujson/src/ujson/Readable.scala
@@ -15,12 +15,11 @@ object Readable extends ReadableLowPri{
   }
   implicit def fromString(s: String) = new fromTransformer(s, StringParser)
   implicit def fromCharSequence(s: CharSequence) = new fromTransformer(s, CharSequenceParser)
-  implicit def fromPath(s: java.nio.file.Path) = {
-    val inputStream = java.nio.file.Files.newInputStream(s)
-    new fromTransformer(inputStream, InputStreamParser) {
-      override def transform[T](f: Visitor[_, T]) =
-        try super.transform(f)
-        finally inputStream.close()
+  implicit def fromPath(s: java.nio.file.Path) = new Readable {
+    override def transform[T](f: Visitor[_, T]) = {
+      val inputStream = java.nio.file.Files.newInputStream(s)
+      try InputStreamParser.transform(inputStream, f)
+      finally inputStream.close()
     }
   }
   implicit def fromFile(s: java.io.File) = fromPath(s.toPath)

--- a/ujson/src/ujson/Readable.scala
+++ b/ujson/src/ujson/Readable.scala
@@ -15,14 +15,15 @@ object Readable extends ReadableLowPri{
   }
   implicit def fromString(s: String) = new fromTransformer(s, StringParser)
   implicit def fromCharSequence(s: CharSequence) = new fromTransformer(s, CharSequenceParser)
-  implicit def fromPath(s: java.nio.file.Path) = new fromTransformer(
-    java.nio.file.Files.newInputStream(s),
-    InputStreamParser
-  )
-  implicit def fromFile(s: java.io.File) = new fromTransformer(
-    java.nio.file.Files.newInputStream(s.toPath),
-    InputStreamParser
-  )
+  implicit def fromPath(s: java.nio.file.Path) = {
+    val inputStream = java.nio.file.Files.newInputStream(s)
+    new fromTransformer(inputStream, InputStreamParser) {
+      override def transform[T](f: Visitor[_, T]) =
+        try super.transform(f)
+        finally inputStream.close()
+    }
+  }
+  implicit def fromFile(s: java.io.File) = fromPath(s.toPath)
   implicit def fromByteBuffer(s: ByteBuffer) = new fromTransformer(s, ByteBufferParser)
   implicit def fromByteArray(s: Array[Byte]) = new fromTransformer(s, ByteArrayParser)
 }


### PR DESCRIPTION
Attempt at fixing #303 

What's confusing about the code (both before and after) is that it creates an InputStream once, and then returns an object that can attempt to consume the InputStream many times. For this reason closing it feels wrong but in any case the InputStream will presumably be useless the next time.

(Unless it's meant to be usable with an `ndjson` file. In which case #303 has no solution.)

I would think a better approach would be that every time `Readable#transform` is called it would create the InputStream from the file, read it, and close the InputStream. But that doesn't seem to fit the whole InputStreamParser + Transformer shape of things.