### PR TITLE
Add support for Scala Native 0.3 and 0.4.0-M2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-sudo: false
+os: linux
 language: scala
 
 script:
-- ./mill -i __.test.test
-
+  - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
+  - ./mill -i __.test.test

--- a/build.sc
+++ b/build.sc
@@ -1,13 +1,29 @@
-import mill._, mill.scalalib._, mill.scalalib.publish._, mill.scalajslib._
+import mill._, mill.scalalib._, mill.scalalib.publish._, mill.scalajslib._, mill.scalanativelib._
+
+val scala211  = "2.11.12"
+val scala212  = "2.12.10"
+val scala213  = "2.13.1"
+val scalaJS06 = "0.6.32"
+val scalaJS1  = "1.0.0"
+
+def acyclicVersion(scalaVersion: String): String = if(scalaVersion.startsWith("2.11.")) "0.1.8" else "0.2.0"
+
+val scalaJVMVersions = Seq(scala212, scala213)
 
 val scalaJSVersions = Seq(
-  ("2.12.8", "0.6.31"),
-  ("2.13.0", "0.6.31"),
-  ("2.12.8", "1.0.0"),
-  ("2.13.0", "1.0.0")
+  (scala212, scalaJS06),
+  (scala213, scalaJS06),
+  (scala212, scalaJS1),
+  (scala213, scalaJS1)
 )
+
+val scalaNativeVersions = Seq(
+  (scala211, "0.3.9"),
+  (scala211, "0.4.0-M2")
+)
+
 trait CommonModule extends ScalaModule {
-  def scalacOptions = T{ if (scalaVersion() == "2.12.8") Seq("-opt:l:method") else Nil }
+  def scalacOptions = T{ if (scalaVersion() == scala212) Seq("-opt:l:method") else Nil }
   def platformSegment: String
 
   def sources = T.sources(
@@ -33,7 +49,7 @@ trait CommonPublishModule extends CommonModule with PublishModule with CrossScal
 }
 
 trait CommonTestModule extends CommonModule with TestModule{
-  def ivyDeps = Agg(ivy"com.lihaoyi::utest::0.7.4", ivy"com.lihaoyi::acyclic:0.2.0")
+  def ivyDeps = Agg(ivy"com.lihaoyi::utest::0.7.4", ivy"com.lihaoyi::acyclic:${acyclicVersion(scalaVersion())}")
   def testFrameworks = Seq("upickle.core.UTestFramework")
 }
 trait CommonJvmModule extends CommonPublishModule{
@@ -55,37 +71,47 @@ trait CommonJsModule extends CommonPublishModule with ScalaJSModule{
   }
 }
 
-object core extends Module {
-  object js extends Cross[CoreJsModule](scalaJSVersions:_*)
-
-  class CoreJsModule(val crossScalaVersion: String, val crossScalaJSVersion: String) extends CommonJsModule {
-    def artifactName = "upickle-core"
-    def ivyDeps = Agg(
-      ivy"org.scala-lang.modules::scala-collection-compat::2.1.4",
-      ivy"com.lihaoyi::geny::0.5.1"
-    )
-
-    object test extends Tests
-  }
-
-  object jvm extends Cross[CoreJvmModule]("2.12.8", "2.13.0")
-  class CoreJvmModule(val crossScalaVersion: String) extends CommonJvmModule {
-    def artifactName = "upickle-core"
-    def ivyDeps = Agg(
-      ivy"org.scala-lang.modules::scala-collection-compat:2.1.4",
-      ivy"com.lihaoyi::geny:0.5.1"
-    )
-
-    object test extends Tests
+trait CommonNativeModule extends CommonPublishModule with ScalaNativeModule{
+  def platformSegment = "native"
+  def crossScalaNativeVersion: String
+  def scalaNativeVersion = crossScalaNativeVersion
+  def millSourcePath = super.millSourcePath / os.up / os.up
+  trait Tests extends super.Tests with CommonTestModule{
+    def platformSegment = "native"
+    def scalaNativeVersion = crossScalaNativeVersion
   }
 }
 
+trait CommonCoreModule extends ScalaModule {
+  def artifactName = "upickle-core"
+  def ivyDeps = Agg(
+    ivy"org.scala-lang.modules::scala-collection-compat::2.1.4",
+    ivy"com.lihaoyi::geny::0.5.1"
+  )
+}
+object core extends Module {
+  object js extends Cross[CoreJsModule](scalaJSVersions:_*)
+
+  class CoreJsModule(val crossScalaVersion: String, val crossScalaJSVersion: String) extends CommonJsModule with CommonCoreModule{
+    object test extends Tests
+  }
+
+  object jvm extends Cross[CoreJvmModule](scalaJVMVersions:_*)
+  class CoreJvmModule(val crossScalaVersion: String) extends CommonJvmModule with CommonCoreModule{
+    object test extends Tests
+  }
+
+  object native extends Cross[CoreNativeModule](scalaNativeVersions:_*)
+  class CoreNativeModule(val crossScalaVersion: String, val crossScalaNativeVersion: String) extends CommonNativeModule with CommonCoreModule{
+    object test extends Tests
+  }
+}
 
 object implicits extends Module {
 
   trait ImplicitsModule extends CommonPublishModule{
     def compileIvyDeps = Agg(
-      ivy"com.lihaoyi::acyclic:0.2.0",
+      ivy"com.lihaoyi::acyclic:${acyclicVersion(scalaVersion())}",
       ivy"org.scala-lang:scala-reflect:${scalaVersion()}"
     )
     def generatedSources = T{
@@ -139,12 +165,26 @@ object implicits extends Module {
     }
   }
 
-  object jvm extends Cross[JvmModule]("2.12.8", "2.13.0")
+  object jvm extends Cross[JvmModule](scalaJVMVersions:_*)
   class JvmModule(val crossScalaVersion: String) extends ImplicitsModule with CommonJvmModule{
     def moduleDeps = Seq(core.jvm())
     def artifactName = "upickle-implicits"
     object test extends Tests {
       def moduleDeps = super.moduleDeps ++ Seq(ujson.jvm().test, core.jvm().test)
+    }
+  }
+
+  object native extends Cross[NativeModule](scalaNativeVersions:_*)
+
+  class NativeModule(val crossScalaVersion: String, val crossScalaNativeVersion: String) extends ImplicitsModule with CommonNativeModule{
+    def moduleDeps = Seq(core.native(crossScalaVersion, crossScalaNativeVersion))
+    def artifactName = "upickle-implicits"
+
+    object test extends Tests {
+      def moduleDeps = super.moduleDeps ++ Seq(
+        ujson.native(crossScalaVersion, crossScalaNativeVersion).test,
+        core.native(crossScalaVersion, crossScalaNativeVersion).test
+      )
     }
   }
 }
@@ -165,12 +205,26 @@ object upack extends Module {
     }
   }
 
-  object jvm extends Cross[JvmModule]("2.12.8", "2.13.0")
+  object jvm extends Cross[JvmModule](scalaJVMVersions:_*)
   class JvmModule(val crossScalaVersion: String) extends CommonJvmModule {
     def moduleDeps = Seq(core.jvm())
     def artifactName = "upack"
     object test extends Tests with CommonModule  {
       def moduleDeps = super.moduleDeps ++ Seq(ujson.jvm().test, core.jvm().test)
+    }
+  }
+
+  object native extends Cross[NativeModule](scalaNativeVersions:_*)
+
+  class NativeModule(val crossScalaVersion: String, val crossScalaNativeVersion: String) extends CommonNativeModule {
+    def moduleDeps = Seq(core.native(crossScalaVersion, crossScalaNativeVersion))
+    def artifactName = "upack"
+
+    object test extends Tests {
+      def moduleDeps = super.moduleDeps ++ Seq(
+        ujson.native(crossScalaVersion, crossScalaNativeVersion).test,
+        core.native(crossScalaVersion, crossScalaNativeVersion).test
+      )
     }
   }
 }
@@ -182,8 +236,8 @@ object ujson extends Module{
     trait JawnTestModule extends CommonTestModule{
       def ivyDeps = T{
         Agg(
-          ivy"org.scalatest::scalatest::3.0.8",
-          ivy"org.scalacheck::scalacheck::1.14.1"
+          ivy"org.scalatest::scalatest::3.1.1",
+          ivy"org.scalatestplus::scalacheck-1-14::3.1.1.1"
         )
       }
       def testFrameworks = Seq("org.scalatest.tools.Framework")
@@ -194,31 +248,34 @@ object ujson extends Module{
   class JsModule(val crossScalaVersion: String, val crossScalaJSVersion: String) extends JsonModule with CommonJsModule{
     def moduleDeps = Seq(core.js(crossScalaVersion, crossScalaJSVersion))
 
-    object test extends Tests with JawnTestModule{
-      def ivyDeps =
-        if (crossScalaJSVersion == "1.0.0-RC2") T{Agg(ivy"com.lihaoyi::utest::0.7.4")}
-        else super.ivyDeps
-      def sources = if (crossScalaJSVersion == "1.0.0-RC2") T.sources() else super.sources
-      def testFrameworks =
-        if (crossScalaJSVersion == "1.0.0-RC2") T(Seq("utest.runner.Framework"))
-        else super.testFrameworks
-    }
+    object test extends Tests with JawnTestModule
   }
 
-  object jvm extends Cross[JvmModule]("2.12.8", "2.13.0")
+  object jvm extends Cross[JvmModule](scalaJVMVersions:_*)
   class JvmModule(val crossScalaVersion: String) extends JsonModule with CommonJvmModule{
     def moduleDeps = Seq(core.jvm())
     object test extends Tests with JawnTestModule
   }
 
-  object argonaut extends Cross[ArgonautModule]("2.12.8", "2.13.0")
+  object native extends Cross[NativeModule](scalaNativeVersions:_*)
+  class NativeModule(val crossScalaVersion: String, val crossScalaNativeVersion: String) extends JsonModule with CommonNativeModule{
+    def moduleDeps = Seq(core.native(crossScalaVersion, crossScalaNativeVersion))
+
+    object test extends Tests with JawnTestModule {
+      def ivyDeps = if(crossScalaNativeVersion == "0.3.9") T(Agg.empty) else super.ivyDeps()
+      def testFrameworks = if(crossScalaNativeVersion == "0.3.9") T(Seq.empty[String]) else super.testFrameworks()
+      def sources = if(crossScalaNativeVersion == "0.3.9") T.sources(Seq.empty) else super.sources
+    }
+  }
+
+  object argonaut extends Cross[ArgonautModule](scalaJVMVersions:_*)
   class ArgonautModule(val crossScalaVersion: String) extends CommonPublishModule{
     def artifactName = "ujson-argonaut"
     def platformSegment = "jvm"
     def moduleDeps = Seq(ujson.jvm())
     def ivyDeps = Agg(ivy"io.argonaut::argonaut:6.2.3")
   }
-  object json4s extends Cross[Json4sModule]("2.12.8", "2.13.0")
+  object json4s extends Cross[Json4sModule](scalaJVMVersions:_*)
   class Json4sModule(val crossScalaVersion: String) extends CommonPublishModule{
     def artifactName = "ujson-json4s"
     def platformSegment = "jvm"
@@ -229,7 +286,7 @@ object ujson extends Module{
     )
   }
 
-  object circe extends Cross[CirceModule]("2.12.8", "2.13.0")
+  object circe extends Cross[CirceModule](scalaJVMVersions:_*)
   class CirceModule(val crossScalaVersion: String) extends CommonPublishModule{
     def artifactName = "ujson-circe"
     def platformSegment = "jvm"
@@ -237,7 +294,7 @@ object ujson extends Module{
     def ivyDeps = Agg(ivy"io.circe::circe-parser:0.12.1")
   }
 
-  object play extends Cross[PlayModule]("2.12.8", "2.13.0")
+  object play extends Cross[PlayModule](scalaJVMVersions:_*)
   class PlayModule(val crossScalaVersion: String) extends CommonPublishModule{
     def artifactName = "ujson-play"
     def platformSegment = "jvm"
@@ -251,7 +308,7 @@ object ujson extends Module{
 trait UpickleModule extends CommonPublishModule{
   def artifactName = "upickle"
   def compileIvyDeps = Agg(
-    ivy"com.lihaoyi::acyclic:0.2.0",
+    ivy"com.lihaoyi::acyclic:${acyclicVersion(scalaVersion())}",
     ivy"org.scala-lang:scala-reflect:${scalaVersion()}",
     ivy"org.scala-lang:scala-compiler:${scalaVersion()}"
   )
@@ -265,7 +322,7 @@ trait UpickleModule extends CommonPublishModule{
 
 
 object upickle extends Module{
-  object jvm extends Cross[JvmModule]("2.12.8", "2.13.0")
+  object jvm extends Cross[JvmModule](scalaJVMVersions:_*)
   class JvmModule(val crossScalaVersion: String) extends UpickleModule with CommonJvmModule{
     def moduleDeps = Seq(ujson.jvm(), upack.jvm(), implicits.jvm())
 
@@ -295,10 +352,23 @@ object upickle extends Module{
       def moduleDeps = super.moduleDeps ++ Seq(core.js(crossScalaVersion, crossScalaJSVersion).test)
     }
   }
+  object native extends Cross[NativeModule](scalaNativeVersions:_*)
+  class NativeModule(val crossScalaVersion: String, val crossScalaNativeVersion: String) extends UpickleModule with CommonNativeModule {
+    def moduleDeps = Seq(
+      ujson.native(crossScalaVersion, crossScalaNativeVersion),
+      upack.native(crossScalaVersion, crossScalaNativeVersion),
+      implicits.native(crossScalaVersion, crossScalaNativeVersion)
+    )
+
+    object test extends Tests with CommonModule{
+      def testFrameworks = Seq("upickle.core.UTestFramework")
+      def moduleDeps = super.moduleDeps ++ Seq(core.native(crossScalaVersion, crossScalaNativeVersion).test)
+    }
+  }
 }
 
 trait BenchModule extends CommonModule{
-  def scalaVersion = "2.13.0"
+  def scalaVersion = scala213
   def millSourcePath = build.millSourcePath / "bench"
   def ivyDeps = Agg(
     ivy"io.circe::circe-core::0.12.1",
@@ -313,9 +383,9 @@ trait BenchModule extends CommonModule{
 
 object bench extends Module {
   object js extends BenchModule with ScalaJSModule {
-    def scalaJSVersion = "0.6.31"
+    def scalaJSVersion = scalaJSVersions.head._2
     def platformSegment = "js"
-    def moduleDeps = Seq(upickle.js("2.13.0", "0.6.31").test)
+    def moduleDeps = Seq(upickle.js(scala213, scalaJS1).test)
     def run(args: String*) = T.command {
       finalMainClassOpt() match{
         case Left(err) => mill.eval.Result.Failure(err)
@@ -332,7 +402,7 @@ object bench extends Module {
 
   object jvm extends BenchModule {
     def platformSegment = "jvm"
-    def moduleDeps = Seq(upickle.jvm("2.13.0").test)
+    def moduleDeps = Seq(upickle.jvm(scala213).test)
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"com.fasterxml.jackson.module::jackson-module-scala:2.9.10",
       ivy"com.fasterxml.jackson.core:jackson-databind:2.9.4",

--- a/build.sc
+++ b/build.sc
@@ -363,6 +363,7 @@ object upickle extends Module{
     object test extends Tests with CommonModule{
       def testFrameworks = if(crossScalaNativeVersion == "0.3.9") T(Seq.empty[String]) else super.testFrameworks()
       def sources = if(crossScalaNativeVersion == "0.3.9") T.sources(Seq.empty) else super.sources
+      def allSourceFiles = T(super.allSourceFiles().filterNot(pr => Seq("Primitive", "Durations").map(s => s"${s}Tests.scala").contains(pr.path.last)))
       def moduleDeps = super.moduleDeps ++ Seq(core.native(crossScalaVersion, crossScalaNativeVersion).test)
     }
   }

--- a/build.sc
+++ b/build.sc
@@ -361,7 +361,8 @@ object upickle extends Module{
     )
 
     object test extends Tests with CommonModule{
-      def testFrameworks = Seq("upickle.core.UTestFramework")
+      def testFrameworks = if(crossScalaNativeVersion == "0.3.9") T(Seq.empty[String]) else super.testFrameworks()
+      def sources = if(crossScalaNativeVersion == "0.3.9") T.sources(Seq.empty) else super.sources
       def moduleDeps = super.moduleDeps ++ Seq(core.native(crossScalaVersion, crossScalaNativeVersion).test)
     }
   }

--- a/core/src-native/upickle/core/Platform.scala
+++ b/core/src-native/upickle/core/Platform.scala
@@ -1,0 +1,6 @@
+package upickle.core
+object Platform{
+  @inline def charAt(s: CharSequence, i: Int) = s.charAt(i)
+  @inline def charAt(s: String, i: Int) = s.charAt(i)
+  @inline def byteAt(s: Array[Byte], i: Int) = s(i)
+}

--- a/mill
+++ b/mill
@@ -3,7 +3,7 @@
 # This is a wrapper script, that automatically download mill from GitHub release pages
 # You can give the required mill version with MILL_VERSION env variable
 # If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
-DEFAULT_MILL_VERSION=0.6.0-15-ee0405
+DEFAULT_MILL_VERSION=0.6.1
 
 set -e
 
@@ -17,13 +17,24 @@ if [ -z "$MILL_VERSION" ] ; then
   fi
 fi
 
-MILL_DOWNLOAD_PATH="$HOME/.mill/download"
-MILL_EXEC_PATH="${MILL_DOWNLOAD_PATH}/$MILL_VERSION"
+if [ "x${XDG_CACHE_HOME}" != "x" ] ; then
+  MILL_DOWNLOAD_PATH="${XDG_CACHE_HOME}/mill/download"
+else
+  MILL_DOWNLOAD_PATH="${HOME}/.cache/mill/download"
+fi
+MILL_EXEC_PATH="${MILL_DOWNLOAD_PATH}/${MILL_VERSION}"
+
+version_remainder="$MILL_VERSION"
+MILL_MAJOR_VERSION="${version_remainder%%.*}"; version_remainder="${version_remainder#*.}"
+MILL_MINOR_VERSION="${version_remainder%%.*}"; version_remainder="${version_remainder#*.}"
 
 if [ ! -x "$MILL_EXEC_PATH" ] ; then
   mkdir -p $MILL_DOWNLOAD_PATH
+  if [ "$MILL_MAJOR_VERSION" -gt 0 ] || [ "$MILL_MINOR_VERSION" -ge 5 ] ; then
+    ASSEMBLY="-assembly"
+  fi
   DOWNLOAD_FILE=$MILL_EXEC_PATH-tmp-download
-  MILL_DOWNLOAD_URL="https://github.com/lihaoyi/mill/releases/download/${MILL_VERSION%%-*}/$MILL_VERSION-assembly"
+  MILL_DOWNLOAD_URL="https://github.com/lihaoyi/mill/releases/download/${MILL_VERSION%%-*}/$MILL_VERSION${ASSEMBLY}"
   curl --fail -L -o "$DOWNLOAD_FILE" "$MILL_DOWNLOAD_URL"
   chmod +x "$DOWNLOAD_FILE"
   mv "$DOWNLOAD_FILE" "$MILL_EXEC_PATH"

--- a/ujson/test/src-jvm/ujson/ChannelSpec.scala
+++ b/ujson/test/src-jvm/ujson/ChannelSpec.scala
@@ -1,9 +1,12 @@
 package ujson
 
-import org.scalatest._
+import org.scalatest.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
 import upickle.core.NoOpVisitor
 
-class ChannelSpec extends PropSpec with Matchers {
+class ChannelSpec extends AnyPropSpec with Matchers with ScalaCheckPropertyChecks {
 
   val M = 1
   val q = "\""

--- a/ujson/test/src-jvm/ujson/FileJNumIndexCheck.scala
+++ b/ujson/test/src-jvm/ujson/FileJNumIndexCheck.scala
@@ -1,9 +1,10 @@
 package ujson
 
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class FileJNumIndexCheck extends PropSpec with Matchers with PropertyChecks {
+class FileJNumIndexCheck extends AnyPropSpec with Matchers with ScalaCheckPropertyChecks {
 
   property("visitFloat64StringParts provides the correct indices with parseFromFile") {
     forAll { (value: BigDecimal) =>

--- a/ujson/test/src/ujson/BoolSpec.scala
+++ b/ujson/test/src/ujson/BoolSpec.scala
@@ -1,9 +1,10 @@
 package ujson
 
 import org.scalatest._
-import org.scalatest.prop._
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.scalacheck._
 
-class BoolSpec extends PropSpec with Matchers with PropertyChecks with Inside {
+class BoolSpec extends propspec.AnyPropSpec with Matchers with ScalaCheckPropertyChecks with Inside {
 
   property("ujson.Bool apply") {
     ujson.Bool(true) shouldBe ujson.True

--- a/ujson/test/src/ujson/CharBuilderSpec.scala
+++ b/ujson/test/src/ujson/CharBuilderSpec.scala
@@ -1,9 +1,10 @@
 package ujson
 
 import org.scalatest._
-import org.scalatest.prop._
+import org.scalatest.propspec._
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class CharBuilderSpec extends PropSpec with Matchers with PropertyChecks {
+class CharBuilderSpec extends AnyPropSpec with Matchers with ScalaCheckPropertyChecks {
 
   property("append") {
     forAll { xs: List[Char] =>

--- a/ujson/test/src/ujson/JNumIndexCheck.scala
+++ b/ujson/test/src/ujson/JNumIndexCheck.scala
@@ -2,8 +2,9 @@ package ujson
 
 import java.nio.ByteBuffer
 
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import upickle.core.{ArrVisitor, ObjVisitor, Visitor}
 object JNumIndexCheckFacade extends JsVisitor[Boolean, Boolean] {
   def visitArray(length: Int, index: Int)  = new ArrVisitor[Boolean, Boolean] {
@@ -42,7 +43,7 @@ object JNumIndexCheckFacade extends JsVisitor[Boolean, Boolean] {
 }
 
 
-class JNumIndexCheck extends PropSpec with Matchers with PropertyChecks {
+class JNumIndexCheck extends AnyPropSpec with Matchers with ScalaCheckPropertyChecks {
 
   property("visitFloat64StringParts provides the correct indices with parseFromString") {
     forAll { (value: BigDecimal) =>

--- a/ujson/test/src/ujson/SyntaxCheck.scala
+++ b/ujson/test/src/ujson/SyntaxCheck.scala
@@ -6,12 +6,14 @@ import java.nio.charset.StandardCharsets
 import org.scalacheck.Gen._
 import org.scalacheck._
 import org.scalatest._
-import org.scalatest.prop._
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
 import upickle.core.NoOpVisitor
 
 import scala.util.Try
 
-class SyntaxCheck extends PropSpec with Matchers with PropertyChecks {
+class SyntaxCheck extends AnyPropSpec with Matchers with ScalaCheckPropertyChecks {
 
   // failed to detect some failures in issue #243 at minSuccessful=10. Raised to minSuccessful=100.
   override implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 100)

--- a/upickle/src-native/upickle/WebJson.scala
+++ b/upickle/src-native/upickle/WebJson.scala
@@ -1,0 +1,5 @@
+package upickle
+
+trait WebJson extends upickle.core.Types {
+
+}

--- a/upickle/test/src/upickle/DurationsTests.scala
+++ b/upickle/test/src/upickle/DurationsTests.scala
@@ -1,0 +1,17 @@
+package upickle
+
+import utest._
+import TestUtil._
+import scala.concurrent.duration._
+
+object DurationsTests extends TestSuite {
+  val tests = Tests {
+    test("durations"){
+      test("inf") - rw(Duration.Inf, """ "inf" """)
+      "-inf" - rw(Duration.MinusInf, """ "-inf" """)
+      test("undef") - rw(Duration.Undefined, """ "undef" """)
+      "1-second" - rw(1.second, """ "1000000000" """)
+      "2-hour" - rw(2.hours, """ "7200000000000" """)
+    }
+  }
+}

--- a/upickle/test/src/upickle/StructTests.scala
+++ b/upickle/test/src/upickle/StructTests.scala
@@ -126,14 +126,6 @@ object StructTests extends TestSuite {
       }
     }
 
-    test("durations"){
-      test("inf") - rw(Duration.Inf, """ "inf" """)
-      "-inf" - rw(Duration.MinusInf, """ "-inf" """)
-      test("undef") - rw(Duration.Undefined, """ "undef" """)
-      "1-second" - rw(1.second, """ "1000000000" """)
-      "2-hour" - rw(2.hours, """ "7200000000000" """)
-    }
-
     test("combinations"){
       test("SeqListMapOptionString") - rw[Seq[List[Map[Option[String], String]]]](
         Seq(Nil, List(Map(Some("omg") -> "omg"), Map(Some("lol") -> "lol", None -> "")), List(Map())),

--- a/upickle/test/src/upickle/example/ExampleTests.scala
+++ b/upickle/test/src/upickle/example/ExampleTests.scala
@@ -9,6 +9,7 @@ import upickle.default.{macroRW, ReadWriter => RW}
 import ujson.{IncompleteParseException, ParseException, Readable}
 import ujson.{BytesRenderer, Value, StringRenderer}
 import upickle.core.{NoOpVisitor, Visitor}
+
 object Simple {
   case class Thing(myFieldA: Int, myFieldB: String)
   object Thing{
@@ -278,7 +279,7 @@ object ExampleTests extends TestSuite {
       test("snakeCase"){
         object SnakePickle extends upickle.AttributeTagged{
           def camelToSnake(s: String) = {
-            s.split("(?=[A-Z])", -1).map(_.toLowerCase).mkString("_")
+            s.replaceAll("([A-Z])","#$1").split('#').map(_.toLowerCase).mkString("_")
           }
           def snakeToCamel(s: String) = {
             val res = s.split("_", -1).map(x => x(0).toUpper + x.drop(1)).mkString


### PR DESCRIPTION
- Update Scala 2.12 to 2.12.10
- Update Scala 2.13 to 2.13.1
- Update Mill script to 0.6.1
- Update Scalatest to 3.1.1
- Use ScalatestPlus scalacheck for generators
- Refactor tests to use new Scalatest
- Enable scalatest tests for all platforms except Scala Native 0.3.9 (no artifact)
- Fix Travis deprecations