### PR TITLE
bump mill to 0.7.3

### DIFF
--- a/mill
+++ b/mill
@@ -3,7 +3,7 @@
 # This is a wrapper script, that automatically download mill from GitHub release pages
 # You can give the required mill version with MILL_VERSION env variable
 # If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
-DEFAULT_MILL_VERSION=0.6.1-122-5be570
+DEFAULT_MILL_VERSION=0.7.3
 
 set -e
 


### PR DESCRIPTION
`./mill mill.scalalib.GenIdea/idea` fails on master. Updating mill seems to fix.

Against old version:
```
./mill mill.scalalib.GenIdea/idea

[1/1] mill.scalalib.GenIdea.idea
Analyzing modules ...
[1/1] mill.scalalib.GenIdea.idea | Downloading [20/20] artifacts (~0/0 bytes)
1 targets failed
mill.scalalib.GenIdea.idea scala.MatchError: Failure(
Resolution failed for 5 modules:
--------------------------------------------
  com.lihaoyi:mill-scalalib_2.12:0.6.1-122-5be570
	not found: /Users/doug.roper/.ivy2/local/com.lihaoyi/mill-scalalib_2.12/0.6.1-122-5be570/ivys/ivy.xml
	not found: https://repo1.maven.org/maven2/com/lihaoyi/mill-scalalib_2.12/0.6.1-122-5be570/mill-scalalib_2.12-0.6.1-122-5be570.pom
	not found: https://oss.sonatype.org/content/repositories/releases/com/lihaoyi/mill-scalalib_2.12/0.6.1-122-5be570/mill-scalalib_2.12-0.6.1-122-5be570.pom
  com.lihaoyi:mill-scalajslib_2.12:0.6.1-122-5be570
	not found: /Users/doug.roper/.ivy2/local/com.lihaoyi/mill-scalajslib_2.12/0.6.1-122-5be570/ivys/ivy.xml
	not found: https://repo1.maven.org/maven2/com/lihaoyi/mill-scalajslib_2.12/0.6.1-122-5be570/mill-scalajslib_2.12-0.6.1-122-5be570.pom
	not found: https://oss.sonatype.org/content/repositories/releases/com/lihaoyi/mill-scalajslib_2.12/0.6.1-122-5be570/mill-scalajslib_2.12-0.6.1-122-5be570.pom
  com.lihaoyi:mill-main-core_2.12:0.6.1-122-5be570
	not found: /Users/doug.roper/.ivy2/local/com.lihaoyi/mill-main-core_2.12/0.6.1-122-5be570/ivys/ivy.xml
	not found: https://repo1.maven.org/maven2/com/lihaoyi/mill-main-core_2.12/0.6.1-122-5be570/mill-main-core_2.12-0.6.1-122-5be570.pom
	not found: https://oss.sonatype.org/content/repositories/releases/com/lihaoyi/mill-main-core_2.12/0.6.1-122-5be570/mill-main-core_2.12-0.6.1-122-5be570.pom
  com.lihaoyi:mill-main-api_2.12:0.6.1-122-5be570
	not found: /Users/doug.roper/.ivy2/local/com.lihaoyi/mill-main-api_2.12/0.6.1-122-5be570/ivys/ivy.xml
	not found: https://repo1.maven.org/maven2/com/lihaoyi/mill-main-api_2.12/0.6.1-122-5be570/mill-main-api_2.12-0.6.1-122-5be570.pom
	not found: https://oss.sonatype.org/content/repositories/releases/com/lihaoyi/mill-main-api_2.12/0.6.1-122-5be570/mill-main-api_2.12-0.6.1-122-5be570.pom
  com.lihaoyi:mill-main-moduledefs_2.12:0.6.1-122-5be570
	not found: /Users/doug.roper/.ivy2/local/com.lihaoyi/mill-main-moduledefs_2.12/0.6.1-122-5be570/ivys/ivy.xml
	not found: https://repo1.maven.org/maven2/com/lihaoyi/mill-main-moduledefs_2.12/0.6.1-122-5be570/mill-main-moduledefs_2.12-0.6.1-122-5be570.pom
	not found: https://oss.sonatype.org/content/repositories/releases/com/lihaoyi/mill-main-moduledefs_2.12/0.6.1-122-5be570/mill-main-moduledefs_2.12-0.6.1-122-5be570.pom
,None) (of class mill.api.Result$Failure)
    mill.scalalib.GenIdeaImpl.xmlFileLayout(GenIdeaImpl.scala:81)
    mill.scalalib.GenIdeaImpl.run(GenIdeaImpl.scala:37)
    mill.scalalib.GenIdea$.$anonfun$idea$2(GenIdea.scala:14)
    scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
```
