### PR TITLE
Upgrade circe

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -302,7 +302,7 @@ object ujson extends Module{
     def artifactName = "ujson-circe"
     def platformSegment = "jvm"
     def moduleDeps = Seq(ujson.jvm())
-    def ivyDeps = Agg(ivy"io.circe::circe-parser:0.12.1")
+    def ivyDeps = Agg(ivy"io.circe::circe-parser:0.13.0")
   }
 
   object play extends Cross[PlayModule](scala2JVMVersions:_*)


### PR DESCRIPTION
The dep on a old version of circe breaks our mill build as we have another mill plugin that depends on circe 0.13.0.