### PR TITLE
Add extensions to support Dotty's 'derives' syntax

### DIFF
--- a/implicits/src-0/upickle/implicits/CaseClassReader.scala
+++ b/implicits/src-0/upickle/implicits/CaseClassReader.scala
@@ -79,4 +79,9 @@ trait CaseClassReaderPiece extends MacrosCommon:
 
   inline given [T <: Singleton: Mirror.Of] as Reader[T] = macroR[T]
 
+  // see comment in MacroImplicits as to why Dotty's extension methods aren't used here
+  implicit class ReaderExtension(r: Reader.type):
+    inline def derived[T](using Mirror.Of[T]): Reader[T] = macroR[T]
+  end ReaderExtension
+
 end CaseClassReaderPiece

--- a/implicits/src-0/upickle/implicits/CaseClassWriter.scala
+++ b/implicits/src-0/upickle/implicits/CaseClassWriter.scala
@@ -61,4 +61,9 @@ trait CaseClassWriterPiece extends MacrosCommon:
 
   inline given [T <: Singleton: Mirror.Of: ClassTag] as Writer[T] = macroW[T]
 
+  // see comment in MacroImplicits as to why Dotty's extension methods aren't used here
+  implicit class WriterExtension(r: Writer.type):
+    inline def derived[T](using Mirror.Of[T], ClassTag[T]): Writer[T] = macroW[T]
+  end WriterExtension
+
 end CaseClassWriterPiece

--- a/implicits/src-0/upickle/implicits/MacroImplicits.scala
+++ b/implicits/src-0/upickle/implicits/MacroImplicits.scala
@@ -13,4 +13,40 @@ trait MacroImplicits extends Readers with Writers with upickle.core.Annotator:
     )
   end macroRW
 
+
+  // Usually, we would use an extension method to add `derived` to ReadWriter's
+  // companion object. Something along the lines of:
+  //
+  //   extension [T](r: ReadWriter.type)
+  //     inline def derived(using Mirror.Of[T]): ReadWriter[T] = macroRW[T]
+  //
+  // Unfortunately however, the above does not work for typeclass derivation.
+  // Consider the following:
+  //
+  //   case class Foo() derives ReadWriter
+  //
+  // which is syntax sugar for:
+  //
+  //   object Foo:
+  //     given ReadWriter[Foo] = ReadWriter.derived
+  //
+  // Now, since the type parameter of the extension must come after `extension`
+  // and is not allowed to be part of the method itself, the compiler cannot
+  // infer the correct type, and hence the extension lookup fails.
+  //
+  // As is mentioned here, https://dotty.epfl.ch/docs/reference/contextual/extension-methods.html#generic-extensions,
+  // this limitation may be lifted in the future:
+  //
+  // > Note: Type parameters have to be given after the extension keyword; they
+  // > cannot be given after the def. This restriction might be lifted in the
+  // > future once we support multiple type parameter clauses in a method. By
+  // > contrast, using clauses can be defined for the extension as well as per
+  // > def.
+  //
+  // Until that is the case, we'll have to resort to using Scala 2's implicit
+  // classes to emulate extension methods for deriving readers and writers.
+  implicit class ReadWriterExtension(r: ReadWriter.type):
+    inline def derived[T](using Mirror.Of[T], ClassTag[T]): ReadWriter[T] = macroRW[T]
+  end ReadWriterExtension
+
 end MacroImplicits

--- a/upickle/test/src-0/upickle/Derivation.scala
+++ b/upickle/test/src-0/upickle/Derivation.scala
@@ -5,26 +5,18 @@ import utest._
 
 import upickle.default.{ read, write, Reader, ReadWriter }
 
-sealed trait Animal
-object Animal {
-  given ReadWriter[Animal] = upickle.default.macroRW
-}
-case class Person(name: String, address: String,
-  age: Int = 20) extends Animal
-object Person {
-  given ReadWriter[Person] = upickle.default.macroRW
-}
+sealed trait Animal derives ReadWriter
+
+case class Person(name: String, address: String, age: Int = 20)
+  extends Animal
+  derives ReadWriter
 
 case class Cat(name: String, owner: Person)
   extends Animal
-object Cat {
-  given ReadWriter[Cat] = upickle.default.macroRW
-}
+  derives ReadWriter
 
 case class Dog(name: String, age: Int)
-object Dog {
-  given ReadWriter[Dog] = upickle.default.macroRW
-}
+  derives ReadWriter
 
 object DerivationTests extends TestSuite {
 


### PR DESCRIPTION
Unfortunately the new extension method mechanism cannot be used, due to some limitations (as described in the comments).