### PR TITLE
Do not use deprecated scala.deriving.ArrayProduct anymore.

### DIFF
--- a/implicits/src-3/upickle/implicits/CaseClassReader.scala
+++ b/implicits/src-3/upickle/implicits/CaseClassReader.scala
@@ -1,7 +1,7 @@
 package upickle.implicits
 
 import compiletime.{summonInline}
-import deriving.{ArrayProduct, Mirror}
+import deriving.Mirror
 import upickle.core.{ Visitor, ObjVisitor, Annotator }
 
 trait CaseClassReaderPiece extends MacrosCommon:
@@ -64,7 +64,13 @@ trait CaseClassReaderPiece extends MacrosCommon:
           if (!missingKeys.isEmpty) {
             throw new upickle.core.Abort("missing keys in dictionary: " + missingKeys.mkString(", "))
           }
-          m.fromProduct(ArrayProduct(values.toArray))
+
+          val valuesArray = values.toArray
+          m.fromProduct(new Product {
+            def canEqual(that: Any): Boolean = true
+            def productArity: Int = valuesArray.length
+            def productElement(i: Int): Any = valuesArray(i)
+          })
         end make
       }
 

--- a/implicits/src-3/upickle/implicits/CaseClassWriter.scala
+++ b/implicits/src-3/upickle/implicits/CaseClassWriter.scala
@@ -1,7 +1,7 @@
 package upickle.implicits
 
 import compiletime.{summonInline}
-import deriving.{ArrayProduct, Mirror}
+import deriving.Mirror
 import scala.reflect.ClassTag
 import upickle.core.{ Visitor, ObjVisitor, Annotator }
 


### PR DESCRIPTION
Instead, wrap the array in a `Product` explicitly.