### PR TITLE
Reject unpaired JSON surrogate escapes

### DIFF
--- a/ujson/templates/ElemParser.scala
+++ b/ujson/templates/ElemParser.scala
@@ -262,8 +262,8 @@ abstract class ElemParser[J] extends upickle.core.BufferingElemParser{
   /**
    * Generate a Char from the hex digits of "\u1234" (i.e. "1234").
    *
-   * NOTE: This is only capable of generating characters from the basic plane.
-   * This is why it can only return Char instead of Int.
+   * NOTE: Returns a single UTF-16 code unit, which may be a surrogate
+   * (D800-DFFF). Callers are responsible for validating surrogate pairs.
    */
   protected[this] final def descape(i: Int): Char = {
     import upickle.core.RenderUtils.hex
@@ -581,7 +581,10 @@ abstract class ElemParser[J] extends upickle.core.BufferingElemParser{
 
           case 'u' => {
             val escaped = descape(i)
-            if (Character.isHighSurrogate(escaped)) {
+            if (!Character.isSurrogate(escaped)) {
+              outputBuilder.appendC(escaped)
+              i += 6
+            } else if (Character.isHighSurrogate(escaped)) {
               if (getElemSafe(i + 6) != '\\' || getElemSafe(i + 7) != 'u') {
                 die(i + 6, "expected \\u escape after high surrogate")
               }
@@ -592,11 +595,8 @@ abstract class ElemParser[J] extends upickle.core.BufferingElemParser{
               outputBuilder.appendC(escaped)
               outputBuilder.appendC(lowSurrogate)
               i += 12
-            } else if (Character.isLowSurrogate(escaped)) {
-              die(i, "unexpected low surrogate escape")
             } else {
-              outputBuilder.appendC(escaped)
-              i += 6
+              die(i, "unexpected low surrogate escape")
             }
           }
 

--- a/ujson/templates/ElemParser.scala
+++ b/ujson/templates/ElemParser.scala
@@ -580,9 +580,26 @@ abstract class ElemParser[J] extends upickle.core.BufferingElemParser{
           case '\\' => { outputBuilder.append('\\'); i += 2 }
 
           // if there's a problem then descape will explode
-          case 'u' =>
-            outputBuilder.appendC(descape(i))
-            i += 6
+          case 'u' => {
+            val escaped = descape(i)
+            if (Character.isHighSurrogate(escaped)) {
+              if (getElemSafe(i + 6) != '\\' || getElemSafe(i + 7) != 'u') {
+                die(i + 6, "expected low surrogate escape after high surrogate")
+              }
+              val lowSurrogate = descape(i + 6)
+              if (!Character.isLowSurrogate(lowSurrogate)) {
+                die(i + 6, "expected low surrogate escape after high surrogate")
+              }
+              outputBuilder.appendC(escaped)
+              outputBuilder.appendC(lowSurrogate)
+              i += 12
+            } else if (Character.isLowSurrogate(escaped)) {
+              die(i, "unexpected low surrogate escape")
+            } else {
+              outputBuilder.appendC(escaped)
+              i += 6
+            }
+          }
 
           case c => die(i + 1, s"illegal escape sequence after \\")
         }

--- a/ujson/templates/ElemParser.scala
+++ b/ujson/templates/ElemParser.scala
@@ -579,16 +579,15 @@ abstract class ElemParser[J] extends upickle.core.BufferingElemParser{
           case '/' => { outputBuilder.append('/'); i += 2 }
           case '\\' => { outputBuilder.append('\\'); i += 2 }
 
-          // if there's a problem then descape will explode
           case 'u' => {
             val escaped = descape(i)
             if (Character.isHighSurrogate(escaped)) {
               if (getElemSafe(i + 6) != '\\' || getElemSafe(i + 7) != 'u') {
-                die(i + 6, "expected low surrogate escape after high surrogate")
+                die(i + 6, "expected \\u escape after high surrogate")
               }
               val lowSurrogate = descape(i + 6)
               if (!Character.isLowSurrogate(lowSurrogate)) {
-                die(i + 6, "expected low surrogate escape after high surrogate")
+                die(i + 6, "expected low surrogate (\\uDC00-\\uDFFF) after high surrogate")
               }
               outputBuilder.appendC(escaped)
               outputBuilder.appendC(lowSurrogate)

--- a/ujson/test/src/ujson/SyntaxTests.scala
+++ b/ujson/test/src/ujson/SyntaxTests.scala
@@ -43,6 +43,27 @@ object SyntaxTests extends TestSuite{
       test{ TestUtil.checkParse("\" \\r \\n \\f \\t \\b \\\" \\\\ \\/ \"", true) }
       test{ TestUtil.checkParse("\" \\u53c9\\u70e7\\u5305 \"", true) }
       test{ TestUtil.checkParse("\" 叉烧包 \"", true) }
+      test("surrogate escapes") {
+        test("valid pairs") {
+          TestUtil.checkParse("\"\\uD800\\uDC00\"", true)
+          TestUtil.checkParse("\"\\uD83D\\uDE00\"", true)
+          TestUtil.checkParse("\"\\uDBFF\\uDFFF\"", true)
+        }
+        test("unpaired high surrogate") {
+          TestUtil.checkParse("\"\\uD800\"", false)
+          TestUtil.checkParse("\"\\uDBFF\"", false)
+          TestUtil.checkParse("\"\\uD800x\"", false)
+          TestUtil.checkParse("\"\\uD800\\u0041\"", false)
+          TestUtil.checkParse("\"\\uD800\\uD800\"", false)
+        }
+        test("unpaired low surrogate") {
+          TestUtil.checkParse("\"\\uDC00\"", false)
+          TestUtil.checkParse("\"\\uDFFF\"", false)
+        }
+        test("object key") {
+          TestUtil.checkParse("{\"\\uD800\": 1}", false)
+        }
+      }
       test{ TestUtil.checkParse("\" \\k \"", false) }
       test{ TestUtil.checkParse("\" \n \"", false) }
       test{ TestUtil.checkParse("\" \t \"", false) }

--- a/ujson/test/src/ujson/SyntaxTests.scala
+++ b/ujson/test/src/ujson/SyntaxTests.scala
@@ -49,12 +49,22 @@ object SyntaxTests extends TestSuite{
           TestUtil.checkParse("\"\\uD83D\\uDE00\"", true)
           TestUtil.checkParse("\"\\uDBFF\\uDFFF\"", true)
         }
+        test("valid pairs in context") {
+          TestUtil.checkParse("\"abc\\uD83D\\uDE00def\"", true)
+          TestUtil.checkParse("\"\\uD83D\\uDE00\\uD83D\\uDE01\"", true)
+          TestUtil.checkParse("\"\\uD83D\\uDE00\\n\"", true)
+          TestUtil.checkParse("\"\\u53c9\\uD83D\\uDE00\\u70e7\"", true)
+        }
         test("unpaired high surrogate") {
           TestUtil.checkParse("\"\\uD800\"", false)
           TestUtil.checkParse("\"\\uDBFF\"", false)
           TestUtil.checkParse("\"\\uD800x\"", false)
           TestUtil.checkParse("\"\\uD800\\u0041\"", false)
           TestUtil.checkParse("\"\\uD800\\uD800\"", false)
+        }
+        test("high surrogate with bad follow-up") {
+          TestUtil.checkParse("\"\\uD800\\\\uDC00\"", false)
+          TestUtil.checkParse("\"\\uD800\\n\"", false)
         }
         test("unpaired low surrogate") {
           TestUtil.checkParse("\"\\uDC00\"", false)

--- a/ujson/test/src/ujson/TestUtil.scala
+++ b/ujson/test/src/ujson/TestUtil.scala
@@ -72,24 +72,28 @@ object TestUtil {
       assert(r2a.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r2a)
       assert(r3a.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r3a)
       assert(r4a.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r4a)
+      assert(r5a.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r5a)
 
       assert(r0b.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r0a)
       assert(r1b.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r1a)
       assert(r2b.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r2a)
       assert(r3b.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r3a)
       assert(r4b.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r4a)
+      assert(r5b.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r5b)
 
       assert(r0c.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r0a)
       assert(r1c.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r1a)
       assert(r2c.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r2a)
       assert(r3c.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r3a)
       assert(r4c.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r4a)
+      assert(r5c.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r5c)
 
       assert(r0d.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r0a)
       assert(r1d.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r1a)
       assert(r2d.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r2a)
       assert(r3d.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r3a)
       assert(r4d.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r4a)
+      assert(r5d.failed.toOption.exists(_.isInstanceOf[ujson.ParsingFailedException]), r5d)
     }
   }
 }


### PR DESCRIPTION
## Summary

- Reject lone high and low UTF-16 surrogate escapes while parsing JSON strings
- Require a high surrogate escape to be followed immediately by a low surrogate escape
- Preserve valid surrogate pairs across the generated Char and Byte parser backends
- Add regression coverage for string values, object keys, parser/render/validate entry points, input forms, and 2-byte stream buffers

## Motivation

ujson currently exposes unpaired `\uD800`-`\uDFFF` escapes as raw UTF-16 surrogate halves. This leaks invalid Unicode scalar values to downstream consumers. In particular, sjsonnet uses ujson for `std.parseJson` and `.json` imports, while Jsonnet string/codepoint semantics expect Unicode code points.

The validation belongs in ujson's shared string parser, where both halves are available and all values, keys, input forms, and renderers pass through the same path. This avoids downstream post-validation scans.

## Behavior

- `"\uD83D\uDE00"` continues to parse as a valid surrogate pair
- `"\uD800"`, `"\uDC00"`, and mismatched pairs now fail with `ParsingFailedException`
- The same validation applies to object keys

Fixes #722

## Testing

- `./mill 'ujson.jvm[2.13.16].test.testForked'` — 248/248 successful, including the 5 GB streaming test
- `./mill 'ujson.jvm[3.3.7].test.testOnly' ujson.SyntaxTests` — 82/82 successful
- `./mill 'ujson.js[2.13.16].test.testOnly' ujson.SyntaxTests` — 82/82 successful
- Qoder CLI blocker review — no must-fix findings
